### PR TITLE
smartphone styles

### DIFF
--- a/index.h
+++ b/index.h
@@ -69,8 +69,7 @@ const char MAIN_page[] PROGMEM = R"=====(
        align-items: center;
     }
     .single-chart {
-        width: 66%;
-        justify-content: center;
+        hight: 33%;
     }
 }
   </style>

--- a/index.h
+++ b/index.h
@@ -62,6 +62,17 @@ const char MAIN_page[] PROGMEM = R"=====(
   font-size: 0.5em;
   text-anchor: middle;
 }
+/*smartphone styles*/
+@media only screen and (max-width: 639px) {
+    .flex-wrapper {
+       flex-flow: column wrap;
+       align-items: center;
+    }
+    .single-chart {
+        width: 66%;
+        justify-content: center;
+    }
+}
   </style>
 </head>
 


### PR DESCRIPTION
A media query is added to adapt the CO2 meter website to the smartphones screen, making the graphics to be put in columns when the screen width resolution goes below 640px.