### PR TITLE
Add option to show Fahrenheit units on display for temperature

### DIFF
--- a/CO2_Gadget.ino
+++ b/CO2_Gadget.ino
@@ -29,6 +29,7 @@ bool activeBLE =  true;
 bool activeWIFI = true;
 bool activeMQTT = true;
 bool debugSensors = false;
+bool showFahrenheit = false;
 bool inMenu = false;
 bool bleInitialized = false;
 int8_t selectedCO2Sensor = -1;

--- a/CO2_Gadget_Menu.h
+++ b/CO2_Gadget_Menu.h
@@ -505,9 +505,14 @@ result doSetTempOffset(eventMask e, navNode &nav, prompt &item) {
   return proceed;
 }
 
+TOGGLE(showFahrenheit, showFahrenheitMenu, "Units: ", doNothing,noEvent, wrapStyle
+  ,VALUE("Celsius ", false, doNothing, noEvent)
+  ,VALUE("Fahrenheit ", true, doNothing, noEvent));
+
 MENU(temperatureConfigMenu, "Temp Config", doNothing, noEvent, wrapStyle
   ,FIELD(temp, "Temp", " deg C", 0, 9, 0, 0, doNothing, noEvent, noStyle)
   ,altFIELD(decPlaces<1>::menuField,tempOffset,"Offset"," deg C",-50,50,1,0.1,doSetTempOffset,(eventMask)(enterEvent | exitEvent | updateEvent),wrapStyle)
+  ,SUBMENU(showFahrenheitMenu)
   ,EXIT("<Back"));
 
 TOGGLE(displayOffOnExternalPower, activeDisplayOffMenuOnBattery, "Off on USB: ", doNothing,noEvent, wrapStyle

--- a/CO2_Gadget_Preferences.h
+++ b/CO2_Gadget_Preferences.h
@@ -34,6 +34,7 @@ void printPreferences() {
   Serial.printf("hostName:\t#%s#\n", hostName.c_str());
   Serial.printf("selCO2Sensor:\t #%d#\n", selectedCO2Sensor);
   Serial.printf("debugSensors is:\t#%s#\n", ((debugSensors) ? "Enabled" : "Disabled"));
+  Serial.printf("showFahrenheit is:\t#%s#\n", ((showFahrenheit) ? "Farenheit" : "Celsius"));
   Serial.println("");
 }
 
@@ -69,6 +70,7 @@ void initPreferences() {
   hostName = preferences.getString("hostName", hostName).c_str();
   selectedCO2Sensor = preferences.getUInt("selCO2Sensor", 0);
   debugSensors = preferences.getBool("debugSensors", false);
+  showFahrenheit = preferences.getBool("showFahrenheit", false);
   
   rootTopic.trim();
   mqttClientId.trim();
@@ -120,5 +122,6 @@ void putPreferences() {
   preferences.putString("hostName", hostName);
   preferences.putUInt("selCO2Sensor", selectedCO2Sensor);
   preferences.putBool("debugSensors", debugSensors);
+  preferences.putBool("showFahrenheit", showFahrenheit);
   preferences.end();
 }

--- a/CO2_Gadget_Sensors.h
+++ b/CO2_Gadget_Sensors.h
@@ -12,7 +12,7 @@ bool autoSelfCalibration = false;
 float tempOffset = 0.0f;
 
 uint16_t co2 = 0;
-float temp, hum = 0;
+float temp, tempFahrenheit, hum = 0;
 
 uint16_t co2OrangeRange =
     700; // Default CO2 ppm concentration threshold to display values in orange
@@ -37,6 +37,8 @@ void onSensorDataOk() {
 
   temp = sensors.getTemperature();
   if (temp == 0.0) temp = sensors.getCO2temp();  // TODO: temp could be 0.0
+
+  tempFahrenheit = (temp * 1.8 + 32);
 
   newReadingsAvailable = true;
 }

--- a/CO2_Gadget_TFT.h
+++ b/CO2_Gadget_TFT.h
@@ -131,7 +131,11 @@ void showTemperatureTFT() {
   tft.setTextDatum(BL_DATUM);
   tft.setSwapBytes(true);
   tft.pushImage(2, tft.height()-22, 16, 16, iconTemperature);
-  tft.drawString(String(temp, 1) + "~" , 22 , tft.height()-2);
+  if (showFahrenheit) {
+    tft.drawString(String(tempFahrenheit, 1) + "~" , 22 , tft.height()-2);    
+  } else {
+    tft.drawString(String(temp, 1) + "~" , 22 , tft.height()-2);
+  }  
 }
 
 void showHumidity() {

--- a/platformio.ini
+++ b/platformio.ini
@@ -50,7 +50,7 @@ build_flags =
 
     -D MQTT_BROKER_SERVER="\"192.168.1.145"\"
     -D CO2_GADGET_VERSION="\"0.5."\"
-    -D CO2_GADGET_REV="\"012"\"
+    -D CO2_GADGET_REV="\"014-Feature-FahrenheitTemp"\"
     -D CORE_DEBUG_LEVEL=0
     -D ENABLE_PIN=27        ; Reserved for the future to enable the sensor
     -D ENABLE_PIN_HIGH=1    ; Should be ENABLE_PIN high or low to enable the sensor?


### PR DESCRIPTION
Add option to display real time temperature in Celsius (just on the display)

- [x] Include option in menu
- [x] Include logic to display Fahrenheit (only in display, rest Celsius)
- [x] Include save in NVR preferences
- [x] Update documentation

May be in the future I can add Fahrenheit to other places. Don't know if really needed. 