### PR TITLE
Feature GPIO outputs for relays, LEDs, etc.

### DIFF
--- a/CO2_Gadget.ino
+++ b/CO2_Gadget.ino
@@ -231,6 +231,28 @@ void processPendingCommands() {
   }
 }
 
+void initGPIO() {
+  pinMode(ORANGE_PIN, OUTPUT);
+  digitalWrite(ORANGE_PIN, LOW);
+  pinMode(RED_PIN, OUTPUT);
+  digitalWrite(RED_PIN, LOW);
+}
+
+void alarmsLoop() {
+  if (co2>co2OrangeRange) {
+    digitalWrite(ORANGE_PIN, ORANGE_PIN_HIGH);
+  }
+  if (co2<co2OrangeRange-PIN_HYSTERESIS) {
+    digitalWrite(ORANGE_PIN, ORANGE_PIN_LOW);
+  }
+  if (co2>co2RedRange) {
+    digitalWrite(RED_PIN, RED_PIN_HIGH);
+  }
+  if (co2<co2RedRange-PIN_HYSTERESIS) {
+    digitalWrite(RED_PIN, RED_PIN_LOW);
+  }
+}
+
 void readingsLoop() {
   if (esp_timer_get_time() - lastReadingsCommunicationTime >= startCheckingAfterUs) {
     if (newReadingsAvailable) {
@@ -295,6 +317,7 @@ void setup() {
   setCpuFrequencyMhz(80); // Lower CPU frecuency to reduce power consumption
   initPreferences();
   initBattery();
+  initGPIO();
 #if defined SUPPORT_OLED
   initDisplayOLED();
 #endif
@@ -319,6 +342,7 @@ void setup() {
 void loop() {
   mqttClientLoop();
   sensorsLoop();
+  alarmsLoop();
   processPendingCommands();
   readingsLoop();
   OTALoop();

--- a/CO2_Gadget.ino
+++ b/CO2_Gadget.ino
@@ -239,7 +239,7 @@ void initGPIO() {
 }
 
 void alarmsLoop() {
-  if (co2>co2OrangeRange) {
+  if (co2>=co2OrangeRange) {
     digitalWrite(ORANGE_PIN, ORANGE_PIN_HIGH);
   }
   if (co2<co2OrangeRange-PIN_HYSTERESIS) {
@@ -248,7 +248,7 @@ void alarmsLoop() {
   if (co2>co2RedRange) {
     digitalWrite(RED_PIN, RED_PIN_HIGH);
   }
-  if (co2<co2RedRange-PIN_HYSTERESIS) {
+  if (co2<=co2RedRange-PIN_HYSTERESIS) {
     digitalWrite(RED_PIN, RED_PIN_LOW);
   }
 }

--- a/CO2_Gadget.ino
+++ b/CO2_Gadget.ino
@@ -232,6 +232,8 @@ void processPendingCommands() {
 }
 
 void initGPIO() {
+  pinMode(GREEN_PIN, OUTPUT);
+  digitalWrite(GREEN_PIN, LOW);
   pinMode(ORANGE_PIN, OUTPUT);
   digitalWrite(ORANGE_PIN, LOW);
   pinMode(RED_PIN, OUTPUT);
@@ -239,6 +241,12 @@ void initGPIO() {
 }
 
 void alarmsLoop() {
+  if (co2>=co2OrangeRange) {
+    digitalWrite(GREEN_PIN, GREEN_PIN_LOW);
+  }
+  if (co2<co2OrangeRange) {
+    digitalWrite(GREEN_PIN, GREEN_PIN_HIGH);
+  }
   if (co2>=co2OrangeRange) {
     digitalWrite(ORANGE_PIN, ORANGE_PIN_HIGH);
   }

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This repository is mainly addressed at developers. If you are an end user willin
 - Sending of data via MQTT
 - Receiving remote commands via MQTT
 - Over the air updates OTA*
-- GPIO outputs to, for example, activate air circulation on threshold with hysteresis. Check GPIO to use at [my blog CO2 Gadget firmware page](https://emariete.com/medidor-co2-gadget/)
+- GPIO outputs to, for example, activation of air circulation on threshold with hysteresis. Check GPIO to use at [my blog CO2 Gadget firmware page](https://emariete.com/medidor-co2-gadget/)
 
 # Supported hardware and build
 
@@ -41,7 +41,26 @@ CO2 Gadget right now has support for many different OLED displays (by using the 
 
 ## ESP32 Boards
 
-Supporting any other ESP32 board is very easy.
+Supporting any other ESP32 board is very easy. Yoy just have to setup the pines accordly.
+
+These are the GPIOs used by each predefined board:
+
+| Flavour | Display | RX/TX | I2C | UP/DWN  | GPIO EN | GPIO Green | GPIO Orange  | GPIO Red
+|:-----------------------|:----------------:|:--------:|:--------:|:--------:|:--------:|:--------:|:--------:|:--------:|
+| TTGO_TDISPLAY	TFT      | 240×135          | 13/12   | 21/22 | 35/0  | 27 | 25 | 32 | 32
+| TTGO_TDISPLAY_SANDWICH | TFT 240×135      | 13/12   | 22/21 | 35/0  | 27 | 25 | 32 | 32
+| esp32dev_OLED	SSH1106  | 128×64           | 17/16   | 21/22 | 35/34 | 27 | 25 | 32 | 32
+| esp32dev_OLED_OTA      | SSH1106-128×64   | 17/16	  | 21/22 | 35/34 | 27 | 25 | 32 | 32
+
+- Variant: Name of the firmware variant, or flavor.
+- Display: Display supported by each flavor.
+- RX / TX: Pins (GPIO) used for connection of sensors connected by Serial port.
+- I2C: Pins (GPIO) corresponding to the I2C bus for connection of I2C sensors and displays.
+- UP / DWN: Pins (GPIO) to which to connect the "Up" and "Down" buttons. They are optional as CO2 Gadget is fully functional with no buttons attached.
+- EN: Pin (GPIO) that supplies an ENABLE signal for switching the sensors on and off (reserved for future use).
+- Green GPIO: Pin (GPIO) corresponding to the output before reaching the orange level (for relays, alarms, and RGB LED).
+- GPIO Orange: Pin (GPIO) corresponding to the output when the orange level is reached (for relays, alarms, and RGB LED).
+- GPIO Red: Pin (GPIO) corresponding to the output when the orange level is reached (for relays, alarms, and RGB LED).
 
 # Supported sensors
 

--- a/README.md
+++ b/README.md
@@ -10,17 +10,18 @@ This repository is mainly addressed at developers. If you are an end user willin
 
 ![CO2 Gadget](https://emariete.com/wp-content/uploads/2021/09/Medidor-CO2-Sensirion-MyAmbience-eMariete.png)
 
-# Features (WIP)
+# Features
 
 - Many popular CO2 sensors supported: Sensirion SCD30, Sensirion SCD40, Sensirion SCD41, Senseair S8 LP, Winsen MH-Z19, Cubic CM1106
 - Supports the Air Quality App Sensirion MyAmbiance for iOS and Android with real time visualization, charting and access to historycal data
 - Real time visualization on display, serial port and web page
-- Management and configuration via on screen menu, serial port and web page*
+- Management and configuration via on screen menu and console (serial port)
 - Local data logger with upload to phone by BLE
 - WIFI connection
 - Sending of data via MQTT
 - Receiving remote commands via MQTT
 - Over the air updates OTA*
+- GPIO outputs to, for example, activate air circulation on threshold with hysteresis. Check GPIO to use at [my blog CO2 Gadget firmware page](https://emariete.com/medidor-co2-gadget/)
 
 # Supported hardware and build
 
@@ -29,6 +30,8 @@ This project support a large selection of boards, displays and sensors.
 As an example you can find a very detailed tutorial with step-by-step video on how to build a very compact CO2 Gadget with a TTGO T-Display board and a high quality Sensirion SCD30 dual channel NDIR CO2 sensor and support for battery [here](https://emariete.com/en/meter-co2-display-tft-color-ttgo-t-display-sensirion-scd30-2/).
 
 ![image](https://user-images.githubusercontent.com/11509521/146636210-ee11a49a-5ebc-4e3c-a11e-91e2d8676410.png)
+
+For latest information on other hardware use (boards, sensors, displays, etc), please check GPIO to use at [my blog CO2 Gadget firmware page](https://emariete.com/medidor-co2-gadget/)
 
 ## OLED Displays
 
@@ -172,13 +175,9 @@ When creating a pull request, we recommend that you do the following:
 
 # TODO
 
-- [x] Test and enable WIFI feature
-- [x] Test and enable TFT Display support
-- [x] Test and enable OLED Display support
-- [x] Test and enable MQTT feature
-- [x] Support enabling and disabling of BLE (Bluetooth Low Energy), WiFi and MQTT without recompiling by activating/deactivating on the buit in menu
 - [ ] Implement full support for PM
 - [ ] Test and enable ESP-Now feature
+- [ ] Full configuration vía web page
 
 # Credits
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -50,11 +50,11 @@ build_flags =
 
     -D MQTT_BROKER_SERVER="\"192.168.1.145"\"
     -D CO2_GADGET_VERSION="\"0.5."\"
-    -D CO2_GADGET_REV="\"028-feature-outputs"\"
+    -D CO2_GADGET_REV="\"029-feature-outputs"\"
     -D CORE_DEBUG_LEVEL=0
 	
-    -D BTN_UP 35			; Pinnumber for button for up/previous and select / enter actions
-    -D BTN_DWN 0			; Pinnumber for button for down/next and back / exit actions
+    -D BTN_UP=35			; Pinnumber for button for up/previous and select / enter actions
+    -D BTN_DWN=0			; Pinnumber for button for down/next and back / exit actions
     -D ENABLE_PIN=27        ; Reserved for the future to enable the sensor
     -D ENABLE_PIN_HIGH=1    ; Should be ENABLE_PIN high or low to enable the sensor?
 	-D ORANGE_PIN=32        ; GPIO to go HIGH on orange color range
@@ -66,7 +66,7 @@ build_flags =
 	-D GREEN_PIN=25         ; GPIO to go HIGH bellow range (goes LOW at orange range)
 	-D GREEN_PIN_LOW=0
 	-D GREEN_PIN_HIGH=1    	; Should the GREEN_PIN_HIGH go high or low bellow orange threshold
-	-D PIN_HYSTERESIS = 100 ; Hysteresis PPM to avoid pins going ON and OFF continuously. TODO : Minimum time to switch
+	-D PIN_HYSTERESIS=100 ; Hysteresis PPM to avoid pins going ON and OFF continuously. TODO : Minimum time to switch
     -D WIFI_PRIVACY         ; Uncomment to hide WiFi password in the menu
  	-D SUPPORT_BLE			; Comment to dissable Bluetooth (makes more memory available)
 	; -D SUPPORT_OTA        ; Needs SUPPORT_WIFI

--- a/platformio.ini
+++ b/platformio.ini
@@ -50,13 +50,20 @@ build_flags =
 
     -D MQTT_BROKER_SERVER="\"192.168.1.145"\"
     -D CO2_GADGET_VERSION="\"0.5."\"
-    -D CO2_GADGET_REV="\"026"\"
+    -D CO2_GADGET_REV="\"027-feature-outputs"\"
     -D CORE_DEBUG_LEVEL=0
 	
     -D BTN_UP 35			; Pinnumber for button for up/previous and select / enter actions
     -D BTN_DWN 0			; Pinnumber for button for down/next and back / exit actions
     -D ENABLE_PIN=27        ; Reserved for the future to enable the sensor
     -D ENABLE_PIN_HIGH=1    ; Should be ENABLE_PIN high or low to enable the sensor?
+	-D ORANGE_PIN=32        ; GPIO to go HIGH on orange color range
+	-D ORANGE_PIN_LOW=0
+	-D ORANGE_PIN_HIGH=1    ; Should the ORANGE_PIN_HIGH go high or low at threshold
+	-D RED_PIN=33           ; GPIO to go HIGH on red color range
+	-D RED_PIN_LOW=0
+	-D RED_PIN_HIGH=1    	; Should the RED_PIN_HIGH go high or low at threshold
+	-D PIN_HYSTERESIS = 100 ; Hysteresis PPM to avoid pins going ON and OFF continuously. TODO : Minimum time to switch
     -D WIFI_PRIVACY         ; Uncomment to hide WiFi password in the menu
  	-D SUPPORT_BLE			; Comment to dissable Bluetooth (makes more memory available)
 	; -D SUPPORT_OTA        ; Needs SUPPORT_WIFI

--- a/platformio.ini
+++ b/platformio.ini
@@ -18,8 +18,8 @@ default_envs = TTGO_TDISPLAY, TTGO_TDISPLAY_SANDWICH, esp32dev_OLED
 framework = arduino
 upload_speed = 921600
 monitor_speed = 115200
-monitor_port = COM5
-upload_port = COM5
+monitor_port = COM13
+upload_port = COM13
 monitor_filters = time
 board_build.partitions = CO2_Gadget_Partitions.csv ; Others at Windows at C:\Users\%USER%\AppData\Local\Arduino15\packages\esp32\hardware\esp32\1.0.5\tools\partitions
 ; board_build.partitions = min_spiffs.csv
@@ -50,7 +50,7 @@ build_flags =
 
     -D MQTT_BROKER_SERVER="\"192.168.1.145"\"
     -D CO2_GADGET_VERSION="\"0.5."\"
-    -D CO2_GADGET_REV="\"027-feature-outputs"\"
+    -D CO2_GADGET_REV="\"028-feature-outputs"\"
     -D CORE_DEBUG_LEVEL=0
 	
     -D BTN_UP 35			; Pinnumber for button for up/previous and select / enter actions
@@ -63,6 +63,9 @@ build_flags =
 	-D RED_PIN=33           ; GPIO to go HIGH on red color range
 	-D RED_PIN_LOW=0
 	-D RED_PIN_HIGH=1    	; Should the RED_PIN_HIGH go high or low at threshold
+	-D GREEN_PIN=25         ; GPIO to go HIGH bellow range (goes LOW at orange range)
+	-D GREEN_PIN_LOW=0
+	-D GREEN_PIN_HIGH=1    	; Should the GREEN_PIN_HIGH go high or low bellow orange threshold
 	-D PIN_HYSTERESIS = 100 ; Hysteresis PPM to avoid pins going ON and OFF continuously. TODO : Minimum time to switch
     -D WIFI_PRIVACY         ; Uncomment to hide WiFi password in the menu
  	-D SUPPORT_BLE			; Comment to dissable Bluetooth (makes more memory available)


### PR DESCRIPTION
The concentrations at which these outputs are activated are customizable and coincide with those you have configured as orange level and red level.

Both outputs are activated when reaching the level of that color and do not turn off until the CO2 level drops at least 100 ppm below that level (hysteresis = 100ppm).

Hysteresis prevents the connected device from continually turning on and off if the concentration keeps fluctuating around that concentration).