### PR TITLE
Add functionality for MQTT Alarms

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -50,7 +50,7 @@ build_flags =
 
     -D MQTT_BROKER_SERVER="\"192.168.1.145"\"
     -D CO2_GADGET_VERSION="\"0.5."\"
-    -D CO2_GADGET_REV="\"030"\"
+    -D CO2_GADGET_REV="\"031"\"
     -D CORE_DEBUG_LEVEL=0
 	
     -DBTN_UP=35				; Pinnumber for button for up/previous and select / enter actions


### PR DESCRIPTION
The concentrations at which these messages are sent are customizable and coincide with those you have configured as orange level and red level.

Messages are sent when reaching the level of that color and do not turn off until the CO2 level drops at least 100 ppm below that level (hysteresis = 100ppm).

Hysteresis prevents to continually sending on and off messages if the concentration keeps fluctuating around that concentration.

Message for green is sent with payload ON when concentration is bellow the orange level and with payload OFF as soon as the concentration reaches the orange level.