### PR TITLE
Arregla bug refresco de pantalla al desactivarse el menu por idle bug #134

### DIFF
--- a/CO2_Gadget_Menu.h
+++ b/CO2_Gadget_Menu.h
@@ -28,6 +28,7 @@
 using namespace Menu;
 
 bool changedToIdle = false;
+bool blankScreen = false;
 
 String rightPad(const String &aString, uint8_t aLength) {
     String paddedString = aString;
@@ -210,7 +211,7 @@ result dosetDisplayBrightness(eventMask e, navNode &nav, prompt &item) {
     Serial.flush();
 #endif
 #if defined(SUPPORT_OLED) || defined(SUPPORT_TFT)
-    setDisplayBrightness(DisplayBrightness);
+//    setDisplayBrightness(DisplayBrightness);
 #endif
     return proceed;
 }
@@ -965,7 +966,7 @@ void loadTempArraysWithActualValues() {
 
 // when menu is suspended
 result idle(menuOut &o, idleEvent e) {
-    if (e == idleStart) {
+    if (e == idleStart && changedToIdle==false) {
 #ifdef DEBUG_ARDUINOMENU
         Serial.println("-->[MENU] Event idleStart");
 #endif
@@ -976,10 +977,19 @@ result idle(menuOut &o, idleEvent e) {
         Serial.println("-->[MENU] Event iddling");
 #endif
 #if defined(SUPPORT_TFT) || defined(SUPPORT_OLED)
+         if ( changedToIdle ){
+          changedToIdle = false;
+          blankScreen = true;
+          return quit;
+        }     
+        if ( blankScreen ){
+          blankScreen = false;
+          fillScreen(Black);
+        }
         displayShowValues();
 #endif
     } else if (e == idleEnd) {
-        changedToIdle = true;
+        changedToIdle = false;
 #ifdef DEBUG_ARDUINOMENU
         Serial.println("-->[MENU] Event idleEnd");
 #endif
@@ -1008,7 +1018,7 @@ void menuLoop() {
     }
     nav.doOutput();
     if (nav.sleepTask) {
-        displayShowValues();
+//        displayShowValues();  // No tengo claro qué hace esta linea, creo que sobra
     }
 #elif defined(SUPPORT_OLED)
     if (nav.sleepTask) {

--- a/CO2_Gadget_TFT.h
+++ b/CO2_Gadget_TFT.h
@@ -521,5 +521,9 @@ void displayShowValues() {
     tft.setTextSize(2);
 }
 
+void fillScreen(uint32_t color){
+    tft.fillScreen(color);
+}
+
 #endif  // SUPPORT_TFT
 #endif  // CO2_Gadget_TFT_h


### PR DESCRIPTION
En el menú idle, haciendo la traza me he dado cuenta que ejecutaba dos veces el evento iddling

Aquí una traza (puse nav.timeOut = 5 para no tener que esperar tanto):

> 15:52:51.003 > CO2 Gadget
> 15:52:51.003 > [1] Battery 4.78Volts
> 15:52:51.003 > [2] Information
> 15:52:51.003 > [3] Calibration
> 15:52:51.008 > [4]>Configuration
> 15:52:51.008 > [5] Reboot w/o saving
> 15:52:51.008 > [6] <Exit
> 15:52:57.014 > -->[MENU] Event idleStart
> 15:52:57.022 > -->[MENU] inMenu:         FALSE
> 15:52:57.022 > -->[MENU] Event iddling
> 15:52:57.068 > -->[MENU] Event iddling

Por eso he tenido que crear otro trigger, además del changedToIdle que tú habías definido, para que la primera vez que entrara en idling activara blankScreen para que a la segunda pusiera en negro la pantalla antes de refrescar los datos:
```
         if ( changedToIdle ){
          changedToIdle = false;
          blankScreen = true;
          return quit;
        }     
        if ( blankScreen ){
          blankScreen = false;
          fillScreen(Black);
        }
```