### PR TITLE
Fix Home Assistant MQTT discovery entity IDs

### DIFF
--- a/CO2_Gadget_MQTT.h
+++ b/CO2_Gadget_MQTT.h
@@ -152,6 +152,55 @@ void publishStrDiscoveryMQTT(String topic, String payload, int qos) {
 #endif
 }
 
+String getMQTTDiscoveryObjectId(String devicePrefix, String field) {
+    String source = devicePrefix + "_" + field;
+    String objectId = "";
+    bool lastWasSeparator = false;
+
+    source.toLowerCase();
+    for (uint16_t i = 0; i < source.length(); ++i) {
+        char c = source.charAt(i);
+        if (((c >= 'a') && (c <= 'z')) || ((c >= '0') && (c <= '9'))) {
+            objectId += c;
+            lastWasSeparator = false;
+        } else if (!lastWasSeparator && objectId.length() > 0) {
+            objectId += "_";
+            lastWasSeparator = true;
+        }
+    }
+
+    while (objectId.endsWith("_")) {
+        objectId.remove(objectId.length() - 1);
+    }
+
+    if (objectId.length() == 0) {
+        objectId = "co2_gadget_" + field;
+        objectId.toLowerCase();
+    }
+    return objectId;
+}
+
+bool isMQTTDiscoveryPlaceholderName(String value) {
+    value.trim();
+    value.toLowerCase();
+    return (value.length() == 0) || (value == "unnamed_device") || (value == "unknown");
+}
+
+String getMQTTDiscoveryDeviceName() {
+    String deviceName = String(hostName);
+    if (isMQTTDiscoveryPlaceholderName(deviceName)) {
+        deviceName = String(UNITHOSTNAME);
+    }
+    if (isMQTTDiscoveryPlaceholderName(deviceName)) {
+        deviceName = String(rootTopic);
+    }
+    if (isMQTTDiscoveryPlaceholderName(deviceName)) {
+        deviceName = "CO2-Gadget";
+    }
+    deviceName.trim();
+    return deviceName;
+}
+
 bool sendMQTTDiscoveryTopic(String deviceClass, String stateClass, String entityCategory,
                             String group, String field, String name, String icon, String unit,
                             int qos) {
@@ -159,6 +208,9 @@ bool sendMQTTDiscoveryTopic(String deviceClass, String stateClass, String entity
     String hw_version = String(FLAVOUR);
 
     String maintopic = String(rootTopic);
+    String deviceName = getMQTTDiscoveryDeviceName();
+    String objectId = getMQTTDiscoveryObjectId(deviceName, field);
+    String entityDomain = (field == "problem") ? "binary_sensor" : "sensor";
 
     String topicFull;
     String configTopic;
@@ -176,10 +228,13 @@ bool sendMQTTDiscoveryTopic(String deviceClass, String stateClass, String entity
     payload = String("{") +
               "\"~\": \"" + maintopic + "\"," +
               "\"unique_id\": \"" + maintopic + "-" + configTopic + "\"," +
-              "\"object_id\": \"" + maintopic + "_" + configTopic + "\"," +
+              "\"default_entity_id\": \"" + entityDomain + "." + objectId + "\"," +
               "\"name\": \"" + name + "\"," +
-              "\"icon\": \"mdi:" + icon + "\"," +
-              "\"unit_of_measurement\": \"" + unit + "\",";
+              "\"icon\": \"mdi:" + icon + "\",";
+
+    if (unit != "") {
+        payload += "\"unit_of_measurement\": \"" + unit + "\",";
+    }
 
     if (field == "problem") {  // Special binary sensor which is based on error topic
         payload += "\"state_topic\": \"~/error\",";
@@ -202,7 +257,7 @@ bool sendMQTTDiscoveryTopic(String deviceClass, String stateClass, String entity
 
     payload += String("\"device\": {") +
                "\"identifiers\": [\"" + maintopic + "\"]," +
-               "\"name\": \"" + maintopic + "\"," +
+               "\"name\": \"" + deviceName + "\"," +
                "\"model\": \"CO2 Gadget\"," +
                "\"manufacturer\": \"emariete.com\"," +
                "\"hw_version\": \"" + hw_version + "\"," +


### PR DESCRIPTION
## Summary


This PR updates the MQTT Home Assistant discovery payloads to use `default_entity_id` instead of the deprecated `object_id` field.

Home Assistant deprecated using MQTT discovery `object_id` as the way to suggest entity IDs, and removed support for it in Home Assistant Core 2026.4 after a 6-month deprecation period. The 2026.4 release notes say MQTT `object_id` “has been replaced by the `default_entity_id` configuration option”, and that discovery messages still containing `object_id` will have that option ignored.

Current Home Assistant MQTT documentation also notes that the `<object_id>` segment in the discovery topic does not influence the resulting `entity_id`; `default_entity_id` must be used when the publisher wants to suggest/control the generated entity ID.

## What changed

- Replaces MQTT discovery `"object_id"` with `"default_entity_id"`.
- Generates Home Assistant-compatible entity IDs from the configured device name and sensor field.
- Sanitizes generated IDs to lowercase alphanumeric/underscore format.
- Uses `sensor.<id>` for normal sensor entities.
- Uses `binary_sensor.<id>` for the optional `problem` entity.
- Avoids placeholder device names such as `unnamed_device` / `unknown` in discovery metadata.
- Omits `unit_of_measurement` when the unit is empty, avoiding unnecessary empty-string fields.

## Why

Without this change, Home Assistant Core 2026.4+ ignores `object_id` in MQTT discovery payloads. That means CO2 Gadget can no longer reliably suggest stable entity IDs through the old discovery field.

Using `default_entity_id` keeps discovery aligned with Home Assistant’s current MQTT API and avoids the deprecation/removal path for `object_id`.

## References

- Home Assistant 2026.4 backward-incompatible MQTT change: https://www.home-assistant.io/blog/2026/04/01/release-20264/
- Home Assistant MQTT discovery documentation: https://www.home-assistant.io/integrations/mqtt/
