### PR TITLE
Fix E-Ink deep sleep partial refresh handling

### DIFF
--- a/CO2_Gadget_DeepSleep.h
+++ b/CO2_Gadget_DeepSleep.h
@@ -358,7 +358,9 @@ void doDeepSleepWiFiConnect() {
 void displayFromDeepSleep(bool forceRedraw = false) {
 #ifdef SUPPORT_EINK
     initDisplayFromDeepSleep(forceRedraw);
+    einkDisplayUpdateFromDeepSleep = true;
     displayShowValues(forceRedraw);
+    einkDisplayUpdateFromDeepSleep = false;
 #endif
 }
 
@@ -658,8 +660,16 @@ void handleBLEOnWake() {
 
 void handleDisplayReverseOnWake() {
 #if defined(SUPPORT_TFT) || defined(SUPPORT_OLED) || defined(SUPPORT_EINK)
+    RTC_DATA_ATTR static bool lastDisplayReverseOnWake = false;
+    RTC_DATA_ATTR static bool lastDisplayReverseOnWakeValid = false;
+    bool displayReverseChanged = !lastDisplayReverseOnWakeValid || (lastDisplayReverseOnWake != deepSleepData.displayReverseOnWake);
+
     displayReverse = deepSleepData.displayReverseOnWake;
-    setDisplayReverse(displayReverse);
+    if (displayReverseChanged) {
+        setDisplayReverse(displayReverse);
+        lastDisplayReverseOnWake = displayReverse;
+        lastDisplayReverseOnWakeValid = true;
+    }
     reverseButtons(displayReverse);
 #endif
 }

--- a/CO2_Gadget_DeepSleep.h
+++ b/CO2_Gadget_DeepSleep.h
@@ -358,7 +358,7 @@ void doDeepSleepWiFiConnect() {
 void displayFromDeepSleep(bool forceRedraw = false) {
 #ifdef SUPPORT_EINK
     initDisplayFromDeepSleep(forceRedraw);
-    displayShowValues();
+    displayShowValues(forceRedraw);
 #endif
 }
 
@@ -630,13 +630,11 @@ bool handleLowPowerSensors() {
 
 void handleCycleCountersOnWake() {
     --deepSleepData.cyclesLeftToWiFiConnect;
-    --deepSleepData.cyclesLeftToRedrawDisplay;
     if (deepSleepData.cyclesLeftToWiFiConnect == 65535) deepSleepData.cyclesLeftToWiFiConnect = 0;
-    if (deepSleepData.cyclesLeftToRedrawDisplay == 65535) deepSleepData.cyclesLeftToRedrawDisplay = 0;
 
 #if defined(DEEP_SLEEP_DEBUG)
     Serial.println("-->[DEEP] Cycles left to connect to WiFi: " + String(deepSleepData.cyclesLeftToWiFiConnect));
-    Serial.println("-->[DEEP] Cycles left to redraw E-Ink display: " + String(deepSleepData.cyclesLeftToRedrawDisplay));
+    Serial.println("-->[DEEP] Display redraw cycles left: " + String(deepSleepData.cyclesLeftToRedrawDisplay));
 #endif
 }
 
@@ -756,7 +754,7 @@ void handleWakeupCauseOnWake(esp_sleep_wakeup_cause_t wakeupCause) {
 #if defined(SUPPORT_OLED) || defined(SUPPORT_EINK)
             Serial.println("-->[DEEP] Turn display off before going to deep sleep *");
             delay(10);
-            displaySleep(false);
+            displaySleep(true);
 #endif
             toDeepSleep();
             break;
@@ -849,7 +847,7 @@ void deepSleepLoop() {
 #endif
             Serial.println("-->[DEEP] Display off before going to deep sleep");
             delay(20);
-            displaySleep(false);
+            displaySleep(true);
 #endif
             // deepSleepData.lowPowerMode = MEDIUM_LOWPOWER;
             toDeepSleep();

--- a/CO2_Gadget_DeepSleep.h
+++ b/CO2_Gadget_DeepSleep.h
@@ -632,7 +632,9 @@ bool handleLowPowerSensors() {
 
 void handleCycleCountersOnWake() {
     --deepSleepData.cyclesLeftToWiFiConnect;
+    --deepSleepData.cyclesLeftToRedrawDisplay;
     if (deepSleepData.cyclesLeftToWiFiConnect == 65535) deepSleepData.cyclesLeftToWiFiConnect = 0;
+    if (deepSleepData.cyclesLeftToRedrawDisplay == 65535) deepSleepData.cyclesLeftToRedrawDisplay = 0;
 
 #if defined(DEEP_SLEEP_DEBUG)
     Serial.println("-->[DEEP] Cycles left to connect to WiFi: " + String(deepSleepData.cyclesLeftToWiFiConnect));

--- a/CO2_Gadget_EINK.h
+++ b/CO2_Gadget_EINK.h
@@ -680,12 +680,12 @@ void testRedrawValues(bool randomNumbers = false) {
 void displayShowValues(bool forceRedraw = false) {
     static uint32_t lastDisplayUpdate = 0;
     if (einkDisplayUpdateInProgress) return;
+    if (isDownloadingBLE) return;  // Do not update display while downloading BLE data to MyAmbiance
     if (forceRedraw) {
         thresholdsManager.updatePreviousValues(DISPLAY_SHOW, co2, temp, hum);
     } else if (!thresholdsManager.evaluateThresholds(DISPLAY_SHOW, co2, temp, hum)) {
         return;
     }
-    if (isDownloadingBLE) return;  // Do not update display while downloading BLE data to MyAmbiance
     if (redrawDisplayOnNextLoop) {
         shouldRedrawDisplay = true;
         redrawDisplayOnNextLoop = false;
@@ -757,12 +757,12 @@ void displayShowValues(bool forceRedraw = false) {
 void displayShowValues(bool forceRedraw = false) {
     static uint32_t lastDisplayUpdate = 0;
     if (einkDisplayUpdateInProgress) return;
+    if (isDownloadingBLE) return;  // Do not update display while downloading BLE data to MyAmbiance
     if (forceRedraw) {
         thresholdsManager.updatePreviousValues(DISPLAY_SHOW, co2, temp, hum);
     } else {
         if (!thresholdsManager.evaluateThresholds(DISPLAY_SHOW, co2, temp, hum)) return;
     }
-    if (isDownloadingBLE) return;  // Do not update display while downloading BLE data to MyAmbiance
     if (redrawDisplayOnNextLoop) {
         shouldRedrawDisplay = true;
         redrawDisplayOnNextLoop = false;

--- a/CO2_Gadget_EINK.h
+++ b/CO2_Gadget_EINK.h
@@ -736,7 +736,11 @@ void displayShowValues(bool forceRedraw = false) {
     showEspNowIcon(elementPosition.espNowIconX, elementPosition.espNowIconY, drawAllElements);
 
     einkDisplayUpdateInProgress = true;
-    display.display(true);  // Partial update
+    if (forceRedraw) {
+        display.display();  // Full update
+    } else {
+        display.display(true);  // Partial update
+    }
     einkDisplayUpdateInProgress = false;
 
 #ifdef TIMEDEBUG

--- a/CO2_Gadget_EINK.h
+++ b/CO2_Gadget_EINK.h
@@ -244,12 +244,13 @@ void turnOffDisplay() {
 
 void displaySleep(bool value = true)  // https://github.com/Bodmer/TFT_eSPI/issues/715
 {
-    display.hibernate();  // TODO: Investigate display.hibernate() vs display.powerOff(). Check if this is the correct way to turn off the display. Specially for GDEM029T94
-    // display.powerOff();
     if (value) {
-        display.powerOff();  // Send command to put the display to sleep.
-        delay(10);           // Delay for shutdown time before another command can be sent.
+        display.epd2.setBusyCallback(nullptr);
+        display.hibernate();
+    } else {
+        display.powerOff();
     }
+    delay(10);  // Delay for shutdown time before another command can be sent.
 }
 
 // Function to set the display rotation
@@ -371,10 +372,13 @@ void busyCallbackDeepSleep(const void* p) {
 #endif
 }
 
+static bool einkDisplayUpdateInProgress = false;
+
 void busyCallbackHighPerformance(const void* p) {
 #ifdef DEBUG_EINK
     // Serial.println("[EINK] busyCallbackHighPerformance light sleep");
 #endif
+    if (einkDisplayUpdateInProgress) return;
     menuLoop();
 }
 
@@ -393,7 +397,6 @@ void initDisplayFromDeepSleep(bool forceRedraw = false) {
     RTC_DATA_ATTR static bool firstBoot = true;
     SPI.begin(EPD_SCLK, EPD_MISO, EPD_MOSI);
     display.epd2.setBusyCallback(busyCallbackDeepSleep);  // register callback to be called during BUSY active time
-    setElementLocations();
     if (firstBoot) {
         forceRedraw = true;
         display.init(115200, true, RESETDURATION, false);
@@ -406,7 +409,8 @@ void initDisplayFromDeepSleep(bool forceRedraw = false) {
     setDisplayRotation(1);
     // display.setRotation(1);
     display.setFont(&SmallFont);
-    // display.setTextColor(GxEPD_BLACK);
+    display.setTextColor(GxEPD_BLACK);
+    setElementLocations();
     // display.setFullWindow();
     // display.setPartialWindow(0, 0, display.width(), display.height());
 #ifdef DEBUG_EINK
@@ -674,7 +678,12 @@ void testRedrawValues(bool randomNumbers = false) {
 #ifdef EINKBOARDGDEM0213B74
 void displayShowValues(bool forceRedraw = false) {
     static uint32_t lastDisplayUpdate = 0;
-    if (!thresholdsManager.evaluateThresholds(DISPLAY_SHOW, co2, temp, hum)) return;
+    if (einkDisplayUpdateInProgress) return;
+    if (forceRedraw) {
+        thresholdsManager.updatePreviousValues(DISPLAY_SHOW, co2, temp, hum);
+    } else if (!thresholdsManager.evaluateThresholds(DISPLAY_SHOW, co2, temp, hum)) {
+        return;
+    }
     if (isDownloadingBLE) return;  // Do not update display while downloading BLE data to MyAmbiance
     if (redrawDisplayOnNextLoop) {
         shouldRedrawDisplay = true;
@@ -712,20 +721,27 @@ void displayShowValues(bool forceRedraw = false) {
 #endif
     }
 
+    bool drawAllElements = true;
+
     if (forceRedraw) {
         display.fillScreen(GxEPD_WHITE);
         display.clearScreen(GxEPD_WHITE);
+    } else {
+        display.setPartialWindow(0, 0, display.width(), display.height());
+        display.fillScreen(GxEPD_WHITE);
     }
-    showCO2(co2, elementPosition.co2X, elementPosition.co2Y, forceRedraw);
-    showTemperature(temp, elementPosition.tempXValue, elementPosition.tempYValue, forceRedraw);
-    showHumidity(hum, elementPosition.humidityXValue, elementPosition.humidityYValue, forceRedraw);
+    showCO2(co2, elementPosition.co2X, elementPosition.co2Y, drawAllElements);
+    showTemperature(temp, elementPosition.tempXValue, elementPosition.tempYValue, drawAllElements);
+    showHumidity(hum, elementPosition.humidityXValue, elementPosition.humidityYValue, drawAllElements);
     showBatteryIcon(elementPosition.batteryIconX, elementPosition.batteryIconY, true);
-    showWiFiIcon(elementPosition.wifiIconX, elementPosition.wifiIconY, forceRedraw);
-    showMQTTIcon(elementPosition.mqttIconX, elementPosition.mqttIconY, forceRedraw);
-    showBLEIcon(elementPosition.bleIconX, elementPosition.bleIconY, forceRedraw);
-    showEspNowIcon(elementPosition.espNowIconX, elementPosition.espNowIconY, forceRedraw);
+    showWiFiIcon(elementPosition.wifiIconX, elementPosition.wifiIconY, drawAllElements);
+    showMQTTIcon(elementPosition.mqttIconX, elementPosition.mqttIconY, drawAllElements);
+    showBLEIcon(elementPosition.bleIconX, elementPosition.bleIconY, drawAllElements);
+    showEspNowIcon(elementPosition.espNowIconX, elementPosition.espNowIconY, drawAllElements);
 
+    einkDisplayUpdateInProgress = true;
     display.display(true);  // Partial update
+    einkDisplayUpdateInProgress = false;
 
 #ifdef TIMEDEBUG
     uint32_t elapsed = timer.read();
@@ -739,6 +755,7 @@ void displayShowValues(bool forceRedraw = false) {
 
 void displayShowValues(bool forceRedraw = false) {
     static uint32_t lastDisplayUpdate = 0;
+    if (einkDisplayUpdateInProgress) return;
     if (forceRedraw) {
         thresholdsManager.updatePreviousValues(DISPLAY_SHOW, co2, temp, hum);
     } else {
@@ -781,27 +798,34 @@ void displayShowValues(bool forceRedraw = false) {
 #endif
     }
 
+    bool drawAllElements = true;
+
     if (forceRedraw) {
         display.setFullWindow();
+        display.fillScreen(GxEPD_WHITE);
+    } else {
+        display.setPartialWindow(0, 0, display.width(), display.height());
         display.fillScreen(GxEPD_WHITE);
     }
 
     // testRedrawValues(true);
-    showCO2(co2, elementPosition.co2X, elementPosition.co2Y, forceRedraw);
-    showTemperature(temp, elementPosition.tempXValue, elementPosition.tempYValue, forceRedraw);
-    showHumidity(hum, elementPosition.humidityXValue, elementPosition.humidityYValue, forceRedraw);
+    showCO2(co2, elementPosition.co2X, elementPosition.co2Y, drawAllElements);
+    showTemperature(temp, elementPosition.tempXValue, elementPosition.tempYValue, drawAllElements);
+    showHumidity(hum, elementPosition.humidityXValue, elementPosition.humidityYValue, drawAllElements);
     showBatteryIcon(elementPosition.batteryIconX, elementPosition.batteryIconY, true);
-    showWiFiIcon(elementPosition.wifiIconX, elementPosition.wifiIconY, forceRedraw);
-    showMQTTIcon(elementPosition.mqttIconX, elementPosition.mqttIconY, forceRedraw);
-    showBLEIcon(elementPosition.bleIconX, elementPosition.bleIconY, forceRedraw);
-    showEspNowIcon(elementPosition.espNowIconX, elementPosition.espNowIconY, forceRedraw);
+    showWiFiIcon(elementPosition.wifiIconX, elementPosition.wifiIconY, drawAllElements);
+    showMQTTIcon(elementPosition.mqttIconX, elementPosition.mqttIconY, drawAllElements);
+    showBLEIcon(elementPosition.bleIconX, elementPosition.bleIconY, drawAllElements);
+    showEspNowIcon(elementPosition.espNowIconX, elementPosition.espNowIconY, drawAllElements);
     // display.hibernate();
 
+    einkDisplayUpdateInProgress = true;
     if (forceRedraw) {
         display.display();  // Full update
     } else {
         display.displayWindow(0, 0, display.width(), display.height());  // Refresh screen in partial mode
     }
+    einkDisplayUpdateInProgress = false;
 
 #ifdef TIMEDEBUG
     uint32_t elapsed = timer.read();

--- a/CO2_Gadget_EINK.h
+++ b/CO2_Gadget_EINK.h
@@ -709,12 +709,7 @@ void displayShowValues(bool forceRedraw = false) {
     timer.start();
 #endif
 
-    if (deepSleepData.cyclesLeftToRedrawDisplay > 0) {
-        deepSleepData.cyclesLeftToRedrawDisplay--;
-#ifdef DEBUG_EINK
-        Serial.println("-->[EINK] Cycles left to full refresh of display: " + String(deepSleepData.cyclesLeftToRedrawDisplay));
-#endif
-    } else {
+    if (deepSleepData.cyclesLeftToRedrawDisplay == 0) {
         deepSleepData.cyclesLeftToRedrawDisplay = deepSleepData.redrawDisplayEveryCycles;
         forceRedraw = true;
 #ifdef DEBUG_EINK
@@ -786,12 +781,7 @@ void displayShowValues(bool forceRedraw = false) {
     timer.start();
 #endif
 
-    if (deepSleepData.cyclesLeftToRedrawDisplay > 0) {
-        deepSleepData.cyclesLeftToRedrawDisplay--;
-#ifdef DEBUG_EINK
-        Serial.println("-->[EINK] Cycles left to full refresh of display: " + String(deepSleepData.cyclesLeftToRedrawDisplay));
-#endif
-    } else {
+    if (deepSleepData.cyclesLeftToRedrawDisplay == 0) {
         deepSleepData.cyclesLeftToRedrawDisplay = deepSleepData.redrawDisplayEveryCycles;
         forceRedraw = true;
 #ifdef DEBUG_EINK

--- a/CO2_Gadget_EINK.h
+++ b/CO2_Gadget_EINK.h
@@ -373,6 +373,7 @@ void busyCallbackDeepSleep(const void* p) {
 }
 
 static bool einkDisplayUpdateInProgress = false;
+static bool einkDisplayUpdateFromDeepSleep = false;
 
 void busyCallbackHighPerformance(const void* p) {
 #ifdef DEBUG_EINK
@@ -694,7 +695,7 @@ void displayShowValues(bool forceRedraw = false) {
         shouldRedrawDisplay = false;
     }
     // Return if last update less than 15 seconds ago
-    if (!forceRedraw && (millis() - lastDisplayUpdate < 10000)) {
+    if (!forceRedraw && !einkDisplayUpdateFromDeepSleep && (millis() - lastDisplayUpdate < 10000)) {
         return;
     }
 
@@ -711,7 +712,7 @@ void displayShowValues(bool forceRedraw = false) {
     if (deepSleepData.cyclesLeftToRedrawDisplay > 0) {
         deepSleepData.cyclesLeftToRedrawDisplay--;
 #ifdef DEBUG_EINK
-        Serial.println("-->[EINK] Cycles left to full refresh of display: " + String(cyclesLeftToRedrawDisplay));
+        Serial.println("-->[EINK] Cycles left to full refresh of display: " + String(deepSleepData.cyclesLeftToRedrawDisplay));
 #endif
     } else {
         deepSleepData.cyclesLeftToRedrawDisplay = deepSleepData.redrawDisplayEveryCycles;
@@ -771,7 +772,7 @@ void displayShowValues(bool forceRedraw = false) {
         shouldRedrawDisplay = false;
     }
     // Return if last update less than 15 seconds ago
-    if (!forceRedraw && (millis() - lastDisplayUpdate < 15000)) {
+    if (!forceRedraw && !einkDisplayUpdateFromDeepSleep && (millis() - lastDisplayUpdate < 15000)) {
         return;
     }
 
@@ -788,7 +789,7 @@ void displayShowValues(bool forceRedraw = false) {
     if (deepSleepData.cyclesLeftToRedrawDisplay > 0) {
         deepSleepData.cyclesLeftToRedrawDisplay--;
 #ifdef DEBUG_EINK
-        Serial.println("-->[EINK] Cycles left to full refresh of display: " + String(cyclesLeftToRedrawDisplay));
+        Serial.println("-->[EINK] Cycles left to full refresh of display: " + String(deepSleepData.cyclesLeftToRedrawDisplay));
 #endif
     } else {
         deepSleepData.cyclesLeftToRedrawDisplay = deepSleepData.redrawDisplayEveryCycles;


### PR DESCRIPTION
## Summary

This PR focuses only on E-Ink display handling during low-power/deep-sleep wake cycles.

It keeps the existing periodic full-refresh guard, but avoids turning every deep-sleep display update into a full refresh. Normal wake updates now repaint the full screen content into a full-size partial window, while scheduled/forced redraws still use the full refresh path.

## What changed

- Pass the deep-sleep `forceRedraw` flag through to `displayShowValues(forceRedraw)`.
- Use a full-screen partial window for non-forced E-Ink updates.
- Clear the partial update area with a white background before redrawing all visible E-Ink elements.
- Keep full refresh for first boot / scheduled redraw cycles.
- Avoid double-decrementing `cyclesLeftToRedrawDisplay`; the display refresh counter is now consumed by the display update path.
- Use the E-Ink deep-sleep shutdown path from `development-low-power`: detach the busy callback and call `display.hibernate()` before ESP deep sleep.
- Keep `display.powerOff()` available on the non-hibernate path.
- Set E-Ink text color and element locations after deep-sleep display init.
- Prevent menu-loop re-entry while an E-Ink update is in progress.

## Context

This follows up on #190, where E-Ink support still listed deep-sleep support and optimizing redraw after deep sleep as pending work.

The maintainer also noted there that E-Ink panels are difficult: full redraws flicker and take time, while repeated partial updates can dim or dirty the display. This PR keeps the periodic full refresh as a quality reset, while making normal deep-sleep wake updates cheaper and less disruptive.

This intentionally avoids the more complex per-element change detection approach discussed in #207. Instead, it uses a simpler full-screen partial refresh path that fits the current display API and keeps the change contained.

## Runtime check

Tested 30 consecutive partial E-Ink updates without visible artifacts.

## Verification

- `pio run -e TTGO_TDISPLAY`
- `pio run -e ttgo-t5-EINKBOARDGDEM0213B74`


The E-Ink build resolved and tested with `GxEPD2 @ 1.6.9` through the existing `zinggjm/GxEPD2 @ ^1.5.6` dependency constraint in `platformio.ini`.

## References

- #190: E-Ink support, including pending deep-sleep/redraw optimization work
- #207: previous, more complex E-Ink refresh proposal and review discussion
- #211: existing EINKBOARDGDEM0213B74 full-refresh adjustment

