### PR TITLE
Fix threshold AND/OR web settings

### DIFF
--- a/libs/CO2_Gadget_Thresholds/src/CO2_Gadget_Thresholds.cpp
+++ b/libs/CO2_Gadget_Thresholds/src/CO2_Gadget_Thresholds.cpp
@@ -11,8 +11,8 @@ ThresholdManager::ThresholdManager() {
 
 void ThresholdManager::setThresholds(OutputType outputType, bool enabled, bool useOnlyInLowPower, uint16_t keepAlive, uint16_t co2ThresholdAbsolute, float tempThresholdAbsolute, float humThresholdAbsolute, uint16_t co2ThresholdPercentage, float tempThresholdPercentage, float humThresholdPercentage, bool co2CombineWithAnd, bool tempCombineWithAnd, bool humCombineWithAnd) {
     thresholds[outputType].enabled = enabled;
-    thresholds[outputType].useOnlyInLowPower = false;
-    thresholds[outputType].keepAlive = 0;
+    thresholds[outputType].useOnlyInLowPower = useOnlyInLowPower;
+    thresholds[outputType].keepAlive = keepAlive;
     thresholds[outputType].co2ThresholdAbsolute = co2ThresholdAbsolute;
     thresholds[outputType].tempThresholdAbsolute = tempThresholdAbsolute;
     thresholds[outputType].humThresholdAbsolute = humThresholdAbsolute;
@@ -22,9 +22,9 @@ void ThresholdManager::setThresholds(OutputType outputType, bool enabled, bool u
     thresholds[outputType].previousCO2Value = 0;
     thresholds[outputType].previousTemperatureValue = 0.0f;
     thresholds[outputType].previousHumidityValue = 0.0f;
-    thresholds[outputType].co2CombineWithAnd = true;
-    thresholds[outputType].tempCombineWithAnd = true;
-    thresholds[outputType].humCombineWithAnd = true;
+    thresholds[outputType].co2CombineWithAnd = co2CombineWithAnd;
+    thresholds[outputType].tempCombineWithAnd = tempCombineWithAnd;
+    thresholds[outputType].humCombineWithAnd = humCombineWithAnd;
 #ifdef DEBUG_THRESHOLDS
     Serial.println("-->[THRE] Thresholds set for output type: " + String(outputType));
     Serial.println("-->[THRE] Setting enabled: " + String(enabled));
@@ -153,7 +153,7 @@ bool ThresholdManager::evaluateThresholds(OutputType outputType, uint16_t co2, f
  * @throws None
  */
 String ThresholdManager::getThresholdsAsJson(OutputType outputType) {
-    const size_t capacity = JSON_ARRAY_SIZE(NUM_OUTPUTS) + NUM_OUTPUTS * JSON_OBJECT_SIZE(10);
+    const size_t capacity = JSON_ARRAY_SIZE(NUM_OUTPUTS) + NUM_OUTPUTS * JSON_OBJECT_SIZE(15);
     DynamicJsonDocument doc(capacity);
 
     doc["enabled"] = thresholds[outputType].enabled;
@@ -191,7 +191,7 @@ String ThresholdManager::getThresholdsAsJson(OutputType outputType) {
  * @throws None
  */
 String ThresholdManager::getAllThresholdsAsJson() {
-    const size_t capacity = JSON_ARRAY_SIZE(NUM_OUTPUTS) + NUM_OUTPUTS * JSON_OBJECT_SIZE(10);
+    const size_t capacity = JSON_ARRAY_SIZE(NUM_OUTPUTS) + NUM_OUTPUTS * JSON_OBJECT_SIZE(15);
     DynamicJsonDocument doc(capacity);
 
     for (int i = 0; i < NUM_OUTPUTS; ++i) {
@@ -268,7 +268,7 @@ void ThresholdManager::saveThresholdsToNVR() {
  * @throws None
  */
 void ThresholdManager::setThresholdsFromJSON(String response) {
-    const size_t capacity = JSON_ARRAY_SIZE(NUM_OUTPUTS) + NUM_OUTPUTS * JSON_OBJECT_SIZE(10);
+    const size_t capacity = JSON_ARRAY_SIZE(NUM_OUTPUTS) + NUM_OUTPUTS * JSON_OBJECT_SIZE(15);
     DynamicJsonDocument doc(capacity);
     deserializeJson(doc, response);
 

--- a/webserver/low_power.html
+++ b/webserver/low_power.html
@@ -202,11 +202,9 @@
                             </div>
                             <div>
                                 <label for="thrOnlyInLowPDisplay">Apply threshold only in low power mode</label>
-                                <!-- <input type="radio" id="thrOnlyInLowPDisplay" name="thrOnlyInLowPDisplay" value="true">
-                                <span class="tooltip-icon"><svg viewBox="0 0 512 512" width="14" height="14" fill="currentColor"><path d="M256 0a256 256 0 1 0 0 512A256 256 0 1 0 256 0zM216 336h24V272H216c-13.3 0-24-10.7-24-24s10.7-24 24-24h48c13.3 0 24 10.7 24 24v88h8c13.3 0 24 10.7 24 24s-10.7 24-24 24H216c-13.3 0-24-10.7-24-24s10.7-24 24-24zm40-208a32 32 0 1 1 0 64 32 32 0 1 1 0-64z"/></svg></span> -->
                                 <span class="tooltip-text">Apply the threshold only when the device is in low power
                                     mode.</span>
-                                <input type="radio" id="thrOnlyInLowPDisplay" name="thrOnlyInLowPDisplay" value="false">
+                                <input type="checkbox" id="thrOnlyInLowPDisplay" name="thrOnlyInLowPDisplay" value="false">
                                 <span class="tooltip-icon"><svg viewBox="0 0 512 512" width="14" height="14" fill="currentColor"><path d="M256 0a256 256 0 1 0 0 512A256 256 0 1 0 256 0zM216 336h24V272H216c-13.3 0-24-10.7-24-24s10.7-24 24-24h48c13.3 0 24 10.7 24 24v88h8c13.3 0 24 10.7 24 24s-10.7 24-24 24H216c-13.3 0-24-10.7-24-24s10.7-24 24-24zm40-208a32 32 0 1 1 0 64 32 32 0 1 1 0-64z"/></svg></span>
                                 <span class="tooltip-text">Apply the threshold when the device is not in low power
                                     mode.</span>
@@ -347,7 +345,7 @@
                                 <label for="thrOnlyInLowPBluetooth">Only in low power</label>
                                 <span class="tooltip-text">Apply the threshold only when the device is in low power
                                     mode.</span>
-                                <input type="radio" id="thrOnlyInLowPBluetooth" name="thrOnlyInLowPBluetooth"
+                                <input type="checkbox" id="thrOnlyInLowPBluetooth" name="thrOnlyInLowPBluetooth"
                                     value="false">
                                 <span class="tooltip-icon"><svg viewBox="0 0 512 512" width="14" height="14" fill="currentColor"><path d="M256 0a256 256 0 1 0 0 512A256 256 0 1 0 256 0zM216 336h24V272H216c-13.3 0-24-10.7-24-24s10.7-24 24-24h48c13.3 0 24 10.7 24 24v88h8c13.3 0 24 10.7 24 24s-10.7 24-24 24H216c-13.3 0-24-10.7-24-24s10.7-24 24-24zm40-208a32 32 0 1 1 0 64 32 32 0 1 1 0-64z"/></svg></span>
                                 <span class="tooltip-text">Apply the threshold when the device is not in low power
@@ -493,7 +491,7 @@
                                 <label for="thrOnlyInLowPMQTT">Only in low power</label>
                                 <span class="tooltip-text">Apply the threshold only when the device is in low power
                                     mode.</span>
-                                <input type="radio" id="thrOnlyInLowPMQTT" name="thrOnlyInLowPMQTT" value="false">
+                                <input type="checkbox" id="thrOnlyInLowPMQTT" name="thrOnlyInLowPMQTT" value="false">
                                 <span class="tooltip-icon"><svg viewBox="0 0 512 512" width="14" height="14" fill="currentColor"><path d="M256 0a256 256 0 1 0 0 512A256 256 0 1 0 256 0zM216 336h24V272H216c-13.3 0-24-10.7-24-24s10.7-24 24-24h48c13.3 0 24 10.7 24 24v88h8c13.3 0 24 10.7 24 24s-10.7 24-24 24H216c-13.3 0-24-10.7-24-24s10.7-24 24-24zm40-208a32 32 0 1 1 0 64 32 32 0 1 1 0-64z"/></svg></span>
                                 <span class="tooltip-text">Apply the threshold when the device is not in low power
                                     mode.</span>
@@ -629,7 +627,7 @@
                                 <label for="thrOnlyInLowPESPNOW">Only in low power</label>
                                 <span class="tooltip-text">Apply the threshold only when the device is in low power
                                     mode.</span>
-                                <input type="radio" id="thrOnlyInLowPESPNOW" name="thrOnlyInLowPESPNOW" value="false">
+                                <input type="checkbox" id="thrOnlyInLowPESPNOW" name="thrOnlyInLowPESPNOW" value="false">
                                 <span class="tooltip-icon"><svg viewBox="0 0 512 512" width="14" height="14" fill="currentColor"><path d="M256 0a256 256 0 1 0 0 512A256 256 0 1 0 256 0zM216 336h24V272H216c-13.3 0-24-10.7-24-24s10.7-24 24-24h48c13.3 0 24 10.7 24 24v88h8c13.3 0 24 10.7 24 24s-10.7 24-24 24H216c-13.3 0-24-10.7-24-24s10.7-24 24-24zm40-208a32 32 0 1 1 0 64 32 32 0 1 1 0-64z"/></svg></span>
                                 <span class="tooltip-text">Apply the threshold when the device is not in low power
                                     mode.</span>

--- a/webserver/low_power.js
+++ b/webserver/low_power.js
@@ -63,6 +63,12 @@ function toggle(checkboxId, elementId) {
     checkbox.addEventListener('change', toggleElement);
 }
 
+function setCombineMode(andRadioId, orRadioId, combineWithAnd) {
+    const useAnd = !!combineWithAnd;
+    document.getElementById(andRadioId).checked = useAnd;
+    document.getElementById(orRadioId).checked = !useAnd;
+}
+
 function loadThresholdsFromServer() {
     fetch('/getThresholdsAsJson')
         .then(response => response.json())
@@ -77,9 +83,9 @@ function loadThresholdsFromServer() {
             document.getElementById("tempThresholdPctDisplay").value = data[0].thrTempPer;
             document.getElementById("humThresholdAbsDisplay").value = data[0].thrHumAbs;
             document.getElementById("humThresholdPctDisplay").value = data[0].thrHumPer;
-            document.getElementById("co2ThresholdAnd").checked = data[0].thrCo2CombAnd;
-            document.getElementById("tempThresholdAnd").checked = data[0].thrTempCombAnd;
-            document.getElementById("humThresholdAnd").checked = data[0].thrHumCombAnd;
+            setCombineMode("co2ThresholdAnd", "co2ThresholdOr", data[0].thrCo2CombAnd);
+            setCombineMode("tempThresholdAnd", "tempThresholdOr", data[0].thrTempCombAnd);
+            setCombineMode("humThresholdAnd", "humThresholdOr", data[0].thrHumCombAnd);
 
             document.getElementById("chkBluetooth").checked = data[1].enabled;
             document.getElementById("keepAliveTimeBluetooth").value = data[1].thrKeepAlive;
@@ -90,9 +96,9 @@ function loadThresholdsFromServer() {
             document.getElementById("tempThresholdPctBluetooth").value = data[1].thrTempPer;
             document.getElementById("humThresholdAbsBluetooth").value = data[1].thrHumAbs;
             document.getElementById("humThresholdPctBluetooth").value = data[1].thrHumPer;
-            document.getElementById("co2ThresholdAndBluetooth").checked = data[1].thrCo2CombAnd;
-            document.getElementById("tempThresholdAndBluetooth").checked = data[1].thrTempCombAnd;
-            document.getElementById("humThresholdAndBluetooth").checked = data[1].thrHumCombAnd;
+            setCombineMode("co2ThresholdAndBluetooth", "co2ThresholdOrBluetooth", data[1].thrCo2CombAnd);
+            setCombineMode("tempThresholdAndBluetooth", "tempThresholdOrBluetooth", data[1].thrTempCombAnd);
+            setCombineMode("humThresholdAndBluetooth", "humThresholdOrBluetooth", data[1].thrHumCombAnd);
 
             document.getElementById("chkMQTT").checked = data[2].enabled;
             document.getElementById("keepAliveTimeMQTT").value = data[2].thrKeepAlive;
@@ -103,9 +109,9 @@ function loadThresholdsFromServer() {
             document.getElementById("tempThresholdPctMQTT").value = data[2].thrTempPer;
             document.getElementById("humThresholdAbsMQTT").value = data[2].thrHumAbs;
             document.getElementById("humThresholdPctMQTT").value = data[2].thrHumPer;
-            document.getElementById("co2ThresholdAndMQTT").checked = data[2].thrCo2CombAnd;
-            document.getElementById("tempThresholdAndMQTT").checked = data[2].thrTempCombAnd;
-            document.getElementById("humThresholdAndMQTT").checked = data[2].thrHumCombAnd;
+            setCombineMode("co2ThresholdAndMQTT", "co2ThresholdOrMQTT", data[2].thrCo2CombAnd);
+            setCombineMode("tempThresholdAndMQTT", "tempThresholdOrMQTT", data[2].thrTempCombAnd);
+            setCombineMode("humThresholdAndMQTT", "humThresholdOrMQTT", data[2].thrHumCombAnd);
 
             document.getElementById("chkESPNOW").checked = data[3].enabled;
             document.getElementById("keepAliveTimeESPNOW").value = data[3].thrKeepAlive;
@@ -116,9 +122,9 @@ function loadThresholdsFromServer() {
             document.getElementById("tempThresholdPctESPNOW").value = data[3].thrTempPer;
             document.getElementById("humThresholdAbsESPNOW").value = data[3].thrHumAbs;
             document.getElementById("humThresholdPctESPNOW").value = data[3].thrHumPer;
-            document.getElementById("co2ThresholdAndESPNOW").checked = data[3].thrCo2CombAnd;
-            document.getElementById("tempThresholdAndESPNOW").checked = data[3].thrTempCombAnd;
-            document.getElementById("humThresholdAndESPNOW").checked = data[3].thrHumCombAnd;
+            setCombineMode("co2ThresholdAndESPNOW", "co2ThresholdOrESPNOW", data[3].thrCo2CombAnd);
+            setCombineMode("tempThresholdAndESPNOW", "tempThresholdOrESPNOW", data[3].thrTempCombAnd);
+            setCombineMode("humThresholdAndESPNOW", "humThresholdOrESPNOW", data[3].thrHumCombAnd);
 
             // Toggle visibility of tabs based on checkbox state
             toggle('chkDisplay', 'Display');


### PR DESCRIPTION
Restore saved OR selections in the low-power threshold page by setting both radio buttons when threshold settings are loaded.

Make the low-power-only threshold controls checkboxes so the UI matches the boolean value sent by the JavaScript.

Preserve threshold helper arguments for low-power-only, keep-alive, and AND/OR combine flags, and size the threshold JSON documents for all emitted fields.

Regenerate the compressed low_power HTML and JavaScript assets.