### PR TITLE
Avoid repeated WiFi credential NVR writes

### DIFF
--- a/CO2_Gadget_Preferences.h
+++ b/CO2_Gadget_Preferences.h
@@ -422,8 +422,19 @@ void initPreferences() {
 }
 
 void saveWifiCredentials() {
-    Serial.println("-->[PREF] Saving WiFi credentials to NVR");
+    wifiSSID.trim();
+    wifiPass.trim();
+
     preferences.begin("CO2-Gadget", false);
+    String savedWifiSSID = preferences.getString("wifiSSID", "");
+    String savedWifiPass = preferences.getString("wifiPass", "");
+
+    if ((savedWifiSSID == wifiSSID) && (savedWifiPass == wifiPass)) {
+        preferences.end();
+        return;
+    }
+
+    Serial.println("-->[PREF] Saving WiFi credentials to NVR");
     preferences.putString("wifiSSID", wifiSSID);
     preferences.putString("wifiPass", wifiPass);
     preferences.end();


### PR DESCRIPTION
Check the stored WiFi SSID and password before saving credentials.

Successful reconnects currently call saveWifiCredentials() and rewrite the same SSID/password to NVR even when nothing changed. This is unnecessary during normal operation and especially during low-power/deep-sleep wake cycles where WiFi reconnects repeatedly for MQTT or other scheduled work.

This change keeps the existing save behavior when credentials actually change, but skips the NVR write when the stored values already match.
