### PR TITLE
Fix HA MQTT battery discovery metadata

### DIFF
--- a/CO2_Gadget_MQTT.h
+++ b/CO2_Gadget_MQTT.h
@@ -229,8 +229,11 @@ bool sendMQTTDiscoveryTopic(String deviceClass, String stateClass, String entity
               "\"~\": \"" + maintopic + "\"," +
               "\"unique_id\": \"" + maintopic + "-" + configTopic + "\"," +
               "\"default_entity_id\": \"" + entityDomain + "." + objectId + "\"," +
-              "\"name\": \"" + name + "\"," +
-              "\"icon\": \"mdi:" + icon + "\",";
+              "\"name\": \"" + name + "\",";
+
+    if (icon != "") {
+        payload += "\"icon\": \"mdi:" + icon + "\",";
+    }
 
     if (unit != "") {
         payload += "\"unit_of_measurement\": \"" + unit + "\",";
@@ -290,8 +293,8 @@ bool publishMQTTDiscovery(int qos) {
     allSendsSuccessed |= sendMQTTDiscoveryTopic("",                 "",                  "diagnostic",       "",      "wifiRSSI",    "Wi-Fi RSSI",           "wifi",                     "dBm",      qos);
     // allSendsSuccessed |= sendMQTTDiscoveryTopic("",                 "",                  "diagnostic",       "",      "IP",          "IP",                   "network-outline",          "",         qos);
     // allSendsSuccessed |= sendMQTTDiscoveryTopic("",                 "",                  "diagnostic",       "",      "status",      "Status",               "list-status",              "",         qos);
-    allSendsSuccessed |= sendMQTTDiscoveryTopic("",                 "measurement",       "diagnostic",       "",      "battery",     "Battery",              "",                         "%",        qos);
-    allSendsSuccessed |= sendMQTTDiscoveryTopic("",                 "measurement",       "diagnostic",       "",      "voltage",     "Voltage",              "",                         "V",        qos);
+    allSendsSuccessed |= sendMQTTDiscoveryTopic("battery",          "measurement",       "diagnostic",       "",      "battery",     "Battery",              "",                         "%",        qos);
+    allSendsSuccessed |= sendMQTTDiscoveryTopic("voltage",          "measurement",       "diagnostic",       "",      "voltage",     "Voltage",              "",                         "V",        qos);
 
     allSendsSuccessed |= sendMQTTDiscoveryTopic("carbon_dioxide",   "",                  "",                "",      "co2",         "CO2",                  "molecule-co2",                         "ppm",      qos);
     allSendsSuccessed |= sendMQTTDiscoveryTopic("temperature",      "",                  "",                "",      "temp",        "Temperature",          "temperature-celsius",                  "°C",       qos);


### PR DESCRIPTION
This PR fixes MQTT Home Assistant discovery metadata for the battery-related sensors.

Battery and voltage were already published and working over MQTT, but the discovery payload advertised them as generic measurement sensors. Recent Home Assistant device/maintenance views classify battery-related entities using discovery metadata, so the battery sensor not appears in the expected battery/maintenance UI without the correct `device_class`.

## What changed

- Advertise the battery percentage sensor with `device_class: battery`.
- Advertise the battery voltage sensor with `device_class: voltage`.
- Avoid publishing an empty `mdi:` icon field when no icon is configured for a discovery entity.

## Verification

- `pio run -e ttgo-t5-EINKBOARDDEPG0213BN`
- Runtime check: MQTT battery sensor publishes normally and appears correctly in Home Assistant with the updated discovery metadata.