### PR TITLE
Retain uptime across deep sleep

### DIFF
--- a/CO2_Gadget.ino
+++ b/CO2_Gadget.ino
@@ -248,10 +248,13 @@ String getReliableUptimeFormatted() {
     uint8_t minutes = totalMinutes % 60;
     char uptime[32];
 
-    snprintf(uptime, sizeof(uptime), "%02llud %02uh %02um",
+    snprintf(uptime, sizeof(uptime), "%02llu%c %02u%c %02u%c",
              static_cast<unsigned long long>(days),
+             'd',
              static_cast<unsigned int>(hours),
-             static_cast<unsigned int>(minutes));
+             'h',
+             static_cast<unsigned int>(minutes),
+             'm');
     return String(uptime);
 }
 
@@ -818,7 +821,9 @@ void setup() {
     Serial.println("-->[STUP] lowPowerMode mode (from RTC memory): (" + String(deepSleepData.lowPowerMode) + ") " + getLowPowerModeName(deepSleepData.lowPowerMode));
 
     if ((esp_reset_reason() == ESP_RST_DEEPSLEEP) && (deepSleepData.lowPowerMode != HIGH_PERFORMANCE)) {
-        deepSleepData.uptimeMillis += static_cast<uint64_t>(deepSleepData.timeSleeping) * 1000ULL;
+        if (esp_sleep_get_wakeup_cause() == ESP_SLEEP_WAKEUP_TIMER) {
+            deepSleepData.uptimeMillis += static_cast<uint64_t>(deepSleepData.timeSleeping) * 1000ULL;
+        }
         ++deepSleepData.bootTimes;
         Serial.println("-->[STUP] Boot times from Deep Sleep: " + String(deepSleepData.bootTimes));
         timeToWaitForImprov = 0;

--- a/CO2_Gadget.ino
+++ b/CO2_Gadget.ino
@@ -50,6 +50,8 @@ void putPreferences();                              // Defined in CO2_Gadget_Pre
 void menuLoop();                                    // Defined in CO2_Gadget_Menu.h
 void setBLEHistoryInterval(uint64_t interval);      // Defined in CO2_Gadget_BLE.h
 String getLowPowerModeName(uint16_t mode);          // Defined in CO2_Gadget_DeepSleep.h
+uint64_t getReliableUptimeSeconds();                // Accumulated uptime across deep sleep cycles
+String getReliableUptimeFormatted();                // Accumulated uptime formatted as <dd>d <hh>h <mm>m
 void restartTimerToDeepSleep();                     // Defined in CO2_Gadget_DeepSleep.h
 void toDeepSleep();                                 // Defined in CO2_Gadget_DeepSleep.h
 void setDisplayReverse(bool reverse);               // Defined in CO2_Gadget_TFT.h or CO2_Gadget_OLED.h or CO2_Gadget_EINK.h
@@ -230,9 +232,28 @@ typedef struct {
     uint16_t timeToDisplayOnWake = 3;
     bool measurementsStarted;
     uint64_t bootTimes;
+    uint64_t uptimeMillis;
 } deepSleepData_t;
 
 RTC_DATA_ATTR deepSleepData_t deepSleepData;
+
+uint64_t getReliableUptimeSeconds() {
+    return (deepSleepData.uptimeMillis + millis()) / 1000;
+}
+
+String getReliableUptimeFormatted() {
+    uint64_t totalMinutes = (deepSleepData.uptimeMillis + millis()) / 60000;
+    uint64_t days = totalMinutes / 1440;
+    uint8_t hours = (totalMinutes % 1440) / 60;
+    uint8_t minutes = totalMinutes % 60;
+    char uptime[32];
+
+    snprintf(uptime, sizeof(uptime), "%02llud %02uh %02um",
+             static_cast<unsigned long long>(days),
+             static_cast<unsigned int>(hours),
+             static_cast<unsigned int>(minutes));
+    return String(uptime);
+}
 
 #ifdef BUILD_GIT
 #undef BUILD_GIT
@@ -797,6 +818,7 @@ void setup() {
     Serial.println("-->[STUP] lowPowerMode mode (from RTC memory): (" + String(deepSleepData.lowPowerMode) + ") " + getLowPowerModeName(deepSleepData.lowPowerMode));
 
     if ((esp_reset_reason() == ESP_RST_DEEPSLEEP) && (deepSleepData.lowPowerMode != HIGH_PERFORMANCE)) {
+        deepSleepData.uptimeMillis += static_cast<uint64_t>(deepSleepData.timeSleeping) * 1000ULL;
         ++deepSleepData.bootTimes;
         Serial.println("-->[STUP] Boot times from Deep Sleep: " + String(deepSleepData.bootTimes));
         timeToWaitForImprov = 0;
@@ -836,6 +858,7 @@ void setup() {
     } else {
         // Normal boot from any reason
         if ((esp_reset_reason() == ESP_RST_POWERON) || (esp_reset_reason() == ESP_RST_BROWNOUT) || (esp_reset_reason() == ESP_RST_SW) || (esp_reset_reason() == ESP_RST_PANIC) || (esp_reset_reason() == ESP_RST_INT_WDT) || (esp_reset_reason() == ESP_RST_TASK_WDT) || (esp_reset_reason() == ESP_RST_WDT)) {
+            deepSleepData.uptimeMillis = 0;
             Serial.println("-->[STUP] Initializing from: " + getResetReason());
             initPreferences();
             initThresholds();

--- a/CO2_Gadget_DeepSleep.h
+++ b/CO2_Gadget_DeepSleep.h
@@ -268,6 +268,8 @@ void toDeepSleep() {
 // display.hibernate();
 #endif
 
+    deepSleepData.uptimeMillis += millis();
+
 #if defined(SUPPORT_TFT) || defined(SUPPORT_OLED) || defined(SUPPORT_EINK)
                 deepSleepData.displayReverseOnWake = displayReverse;
 #endif

--- a/CO2_Gadget_MQTT.h
+++ b/CO2_Gadget_MQTT.h
@@ -286,7 +286,7 @@ bool publishMQTTDiscovery(int qos) {
     // TO-DO: Add MAC Address, Hostname, IP and Status to discovery. Don't know why they are not working (home assistant doesn't show them)
     //
     //                                          Device Class        | State Class       | Entity Category   | Group  | Field        | User Friendly Name    | Icon                      | Unit
-    allSendsSuccessed |= sendMQTTDiscoveryTopic("",                 "",                  "diagnostic",       "",      "uptime",      "Uptime",               "clock-time-eight-outline", "s",        qos);
+    allSendsSuccessed |= sendMQTTDiscoveryTopic("",                 "",                  "diagnostic",       "",      "uptime",      "Uptime",               "clock-time-eight-outline", "",         qos);
     // allSendsSuccessed |= sendMQTTDiscoveryTopic("",                 "",                  "diagnostic",       "",      "MAC",         "MAC Address",          "network-outline",          "",         qos);
     // allSendsSuccessed |= sendMQTTDiscoveryTopic("",                 "",                  "diagnostic",       "",      "hostname",    "Hostname",             "network-outline",          "",         qos);
     allSendsSuccessed |= sendMQTTDiscoveryTopic("",                 "measurement",       "diagnostic",       "",      "freeMem",     "Free Memory",          "memory",                   "B",        qos);
@@ -377,7 +377,7 @@ void publishMQTTAlarms() {
 }
 
 void publishMQTTSystemData() {
-    publishIntMQTT("/uptime", millis() / 1000);
+    publishStrMQTT("/uptime", getReliableUptimeFormatted());
     publishFloatMQTT("/voltage", batteryVoltage);
     publishIntMQTT("/battery", batteryLevel);
     publishIntMQTT("/freeMem", ESP.getFreeHeap());


### PR DESCRIPTION
## Summary
This fixes the reported uptime value when the device runs in low-power mode and wakes from deep sleep.

Instead of publishing uptime from `millis()` only, the firmware now keeps an accumulated uptime counter in RTC memory and adds the current boot's `millis()` value when reporting uptime.

## Changes
- Add retained `uptimeMillis` state to `deepSleepData`
- Accumulate elapsed runtime before entering deep sleep
- Add the configured sleep duration after waking from deep sleep
- Publish formatted MQTT uptime using the retained uptime value
- Remove the seconds unit from MQTT discovery for uptime because the published value is now formatted text

## Notes
This PR is intentionally limited to uptime retention/reporting. Related low-power display telemetry fixes are kept in a separate PR for easier review.