### PR TITLE
Cache WiFi RSSI in RTC memory for low-power display updates

### DIFF
--- a/CO2_Gadget.ino
+++ b/CO2_Gadget.ino
@@ -230,6 +230,8 @@ typedef struct {
     bool displayOnWake;
     bool displayReverseOnWake;  // Display reverse on wake. Here to avoid having to read preferences on wake
     uint16_t timeToDisplayOnWake = 3;
+    bool lastWifiRSSIValid;
+    int16_t lastWifiRSSI;
     bool measurementsStarted;
     uint64_t bootTimes;
     uint64_t uptimeMillis;
@@ -864,6 +866,8 @@ void setup() {
         // Normal boot from any reason
         if ((esp_reset_reason() == ESP_RST_POWERON) || (esp_reset_reason() == ESP_RST_BROWNOUT) || (esp_reset_reason() == ESP_RST_SW) || (esp_reset_reason() == ESP_RST_PANIC) || (esp_reset_reason() == ESP_RST_INT_WDT) || (esp_reset_reason() == ESP_RST_TASK_WDT) || (esp_reset_reason() == ESP_RST_WDT)) {
             deepSleepData.uptimeMillis = 0;
+            deepSleepData.lastWifiRSSIValid = false;
+            deepSleepData.lastWifiRSSI = 0;
             Serial.println("-->[STUP] Initializing from: " + getResetReason());
             initPreferences();
             initThresholds();

--- a/CO2_Gadget.ino
+++ b/CO2_Gadget.ino
@@ -230,11 +230,11 @@ typedef struct {
     bool displayOnWake;
     bool displayReverseOnWake;  // Display reverse on wake. Here to avoid having to read preferences on wake
     uint16_t timeToDisplayOnWake = 3;
-    bool lastWifiRSSIValid;
-    int16_t lastWifiRSSI;
     bool measurementsStarted;
     uint64_t bootTimes;
     uint64_t uptimeMillis;
+    bool lastWifiRSSIValid;
+    int16_t lastWifiRSSI;
 } deepSleepData_t;
 
 RTC_DATA_ATTR deepSleepData_t deepSleepData;

--- a/CO2_Gadget_EINK.h
+++ b/CO2_Gadget_EINK.h
@@ -603,7 +603,7 @@ void showWiFiIcon(int32_t posX, int32_t posY, bool forceRedraw) {
         // when is disabled I think is better show nothing but for debug purposes show it in inverse mode
         display.drawBitmap(posX, posY, iconWiFi, 16, 16, GxEPD_BLACK);
     } else {
-        if ((WiFi.status() == WL_CONNECTED) || deepSleepData.lastWifiRSSIValid) {
+        if (deepSleepData.lastWifiRSSIValid) {
             int16_t signalStrength = abs(rssi);
             if (signalStrength < 60)
                 display.drawInvertedBitmap(posX, posY, iconWiFi, 16, 16, GxEPD_BLACK);

--- a/CO2_Gadget_EINK.h
+++ b/CO2_Gadget_EINK.h
@@ -593,7 +593,7 @@ void showWiFiIcon(int32_t posX, int32_t posY, bool forceRedraw) {
         return;
     }
 #endif
-    int8_t rssi = WiFi.RSSI();
+    int16_t rssi = getWiFiRSSIForStatus();
     if (troubledWIFI) {
         display.drawBitmap(posX, posY, iconWiFi, 16, 16, GxEPD_BLACK);
         return;
@@ -603,13 +603,16 @@ void showWiFiIcon(int32_t posX, int32_t posY, bool forceRedraw) {
         // when is disabled I think is better show nothing but for debug purposes show it in inverse mode
         display.drawBitmap(posX, posY, iconWiFi, 16, 16, GxEPD_BLACK);
     } else {
-        if (WiFi.status() == WL_CONNECTED) {
-            if (rssi < 60)
+        if ((WiFi.status() == WL_CONNECTED) || deepSleepData.lastWifiRSSIValid) {
+            int16_t signalStrength = abs(rssi);
+            if (signalStrength < 60)
                 display.drawInvertedBitmap(posX, posY, iconWiFi, 16, 16, GxEPD_BLACK);
-            else if (rssi < 70)
+            else if (signalStrength < 70)
                 display.drawInvertedBitmap(posX, posY, iconWiFiMed, 16, 16, GxEPD_BLACK);
-            else if (rssi < 80)
+            else if (signalStrength < 80)
                 display.drawInvertedBitmap(posX, posY, iconWiFiMed, 16, 16, GxEPD_BLACK);
+            else
+                display.drawInvertedBitmap(posX, posY, iconWiFiLow, 16, 16, GxEPD_BLACK);
         } else {
             display.drawInvertedBitmap(posX, posY, iconWiFiLow, 16, 16, GxEPD_BLACK);
         }

--- a/CO2_Gadget_MQTT.h
+++ b/CO2_Gadget_MQTT.h
@@ -381,7 +381,7 @@ void publishMQTTSystemData() {
     publishFloatMQTT("/voltage", batteryVoltage);
     publishIntMQTT("/battery", batteryLevel);
     publishIntMQTT("/freeMem", ESP.getFreeHeap());
-    publishIntMQTT("/wifiRSSI", WiFi.RSSI());
+    publishIntMQTT("/wifiRSSI", getWiFiRSSIForStatus());
     publishStrMQTT("/IP", WiFi.localIP().toString());
     publishStrMQTT("/MAC", WiFi.macAddress());
     publishStrMQTT("/hostname", hostName);

--- a/CO2_Gadget_TFT.h
+++ b/CO2_Gadget_TFT.h
@@ -776,7 +776,7 @@ void showWiFiIcon(int32_t posX, int32_t posY, bool forceRedraw) {
         return;
     }
     tft.drawRoundRect(posX - 2, posY - 2, 16 + 4, 16 + 4, 2, TFT_DARKGREY);
-    int8_t rssi = WiFi.RSSI();
+    int16_t rssi = getWiFiRSSIForStatus();
     if (troubledWIFI) {
         tft.drawRoundRect(posX - 2, posY - 2, 16 + 4, 16 + 4, 2, TFT_RED);
         tft.drawBitmap(posX, posY, iconWiFi, 16, 16, TFT_BLACK, iconDefaultColor);
@@ -786,13 +786,16 @@ void showWiFiIcon(int32_t posX, int32_t posY, bool forceRedraw) {
     if (!activeWIFI) {
         tft.drawBitmap(posX, posY, iconWiFi, 16, 16, TFT_BLACK, TFT_DARKGREY);
     } else {
-        if (WiFi.status() == WL_CONNECTED) {
-            if (rssi < 60)
+        if ((WiFi.status() == WL_CONNECTED) || deepSleepData.lastWifiRSSIValid) {
+            int16_t signalStrength = abs(rssi);
+            if (signalStrength < 60)
                 tft.drawBitmap(posX, posY, iconWiFi, 16, 16, TFT_BLACK, iconDefaultColor);
-            else if (rssi < 70)
+            else if (signalStrength < 70)
                 tft.drawBitmap(posX, posY, iconWiFiMed, 16, 16, TFT_BLACK, TFT_ORANGE);
-            else if (rssi < 80)
+            else if (signalStrength < 80)
                 tft.drawBitmap(posX, posY, iconWiFiMed, 16, 16, TFT_BLACK, TFT_YELLOW);
+            else
+                tft.drawBitmap(posX, posY, iconWiFiLow, 16, 16, TFT_BLACK, TFT_BLUE);
         } else {
             tft.drawBitmap(posX, posY, iconWiFiLow, 16, 16, TFT_BLACK, TFT_BLUE);
         }

--- a/CO2_Gadget_TFT.h
+++ b/CO2_Gadget_TFT.h
@@ -786,7 +786,7 @@ void showWiFiIcon(int32_t posX, int32_t posY, bool forceRedraw) {
     if (!activeWIFI) {
         tft.drawBitmap(posX, posY, iconWiFi, 16, 16, TFT_BLACK, TFT_DARKGREY);
     } else {
-        if ((WiFi.status() == WL_CONNECTED) || deepSleepData.lastWifiRSSIValid) {
+        if (deepSleepData.lastWifiRSSIValid) {
             int16_t signalStrength = abs(rssi);
             if (signalStrength < 60)
                 tft.drawBitmap(posX, posY, iconWiFi, 16, 16, TFT_BLACK, iconDefaultColor);

--- a/CO2_Gadget_WIFI.h
+++ b/CO2_Gadget_WIFI.h
@@ -381,7 +381,7 @@ void printDisconnectReason(int reasonCode) {
 }
 
 bool isValidWiFiRSSI(int16_t rssi) {
-    return (rssi <= 0) && (rssi >= -100);
+    return (rssi < 0) && (rssi >= -100);
 }
 
 void updateCachedWiFiRSSI() {
@@ -397,7 +397,6 @@ void updateCachedWiFiRSSI() {
 int16_t getWiFiRSSIForStatus() {
     if (WiFi.status() == WL_CONNECTED) {
         updateCachedWiFiRSSI();
-        return deepSleepData.lastWifiRSSI;
     }
 
     return deepSleepData.lastWifiRSSIValid ? deepSleepData.lastWifiRSSI : 0;
@@ -460,7 +459,6 @@ void printWiFiStatus() {  // Print wifi status on serial monitor
     Serial.println(MACAddress);
 
     // Print the received signal strength:
-    updateCachedWiFiRSSI();
     Serial.print("-->[WiFi] Signal strength (RSSI):");
     Serial.print(getWiFiRSSIForStatus());
     Serial.println(" dBm");

--- a/CO2_Gadget_WIFI.h
+++ b/CO2_Gadget_WIFI.h
@@ -380,6 +380,29 @@ void printDisconnectReason(int reasonCode) {
 #endif  // DEBUG_WIFI_EVENTS
 }
 
+bool isValidWiFiRSSI(int16_t rssi) {
+    return (rssi <= 0) && (rssi >= -100);
+}
+
+void updateCachedWiFiRSSI() {
+    if (WiFi.status() != WL_CONNECTED) return;
+
+    int16_t rssi = WiFi.RSSI();
+    if (!isValidWiFiRSSI(rssi)) return;
+
+    deepSleepData.lastWifiRSSI = rssi;
+    deepSleepData.lastWifiRSSIValid = true;
+}
+
+int16_t getWiFiRSSIForStatus() {
+    if (WiFi.status() == WL_CONNECTED) {
+        updateCachedWiFiRSSI();
+        return deepSleepData.lastWifiRSSI;
+    }
+
+    return deepSleepData.lastWifiRSSIValid ? deepSleepData.lastWifiRSSI : 0;
+}
+
 void printWiFiStatus() {  // Print wifi status on serial monitor
 
     // Get current status
@@ -437,8 +460,9 @@ void printWiFiStatus() {  // Print wifi status on serial monitor
     Serial.println(MACAddress);
 
     // Print the received signal strength:
+    updateCachedWiFiRSSI();
     Serial.print("-->[WiFi] Signal strength (RSSI):");
-    Serial.print(WiFi.RSSI());
+    Serial.print(getWiFiRSSIForStatus());
     Serial.println(" dBm");
 
     /*
@@ -824,7 +848,7 @@ String getCO2GadgetStatusAsJson() {
     doc["wifiPass"] = wifiPass;
 #endif
     doc["IP"] = WiFi.localIP().toString();
-    doc["RSSI"] = WiFi.RSSI();
+    doc["RSSI"] = getWiFiRSSIForStatus();
     doc["MACAddress"] = MACAddress;
     doc["hostName"] = hostName;
     doc["useStaticIP"] = useStaticIP;
@@ -1918,6 +1942,7 @@ bool connectToWiFi() {
         Serial.println(MACAddress);
         Serial.print("-->[WiFi] WiFi connected - IP = ");
         Serial.println(WiFi.localIP());
+        updateCachedWiFiRSSI();
         return true;
     }
 }


### PR DESCRIPTION
## Summary
This fixes Wi-Fi RSSI/status display while the device is in low-power flows where Wi-Fi may not currently be connected.

Previously, display and MQTT/status code read `WiFi.RSSI()` directly, which can return invalid or stale-looking values when Wi-Fi is off or disconnected. The firmware now caches the last valid RSSI in RTC memory and reuses it for status display until a new connected RSSI is available.

## Changes
- Add retained `lastWifiRSSI` and `lastWifiRSSIValid` fields
- Cache RSSI only when Wi-Fi is connected and the reading is valid
- Use cached RSSI for E-Ink/TFT Wi-Fi icons
- Use the same RSSI helper for MQTT/status JSON
- Reset cached RSSI on fresh boot/reset

## Notes
This PR is intentionally separate from the uptime retention fix so each low-power telemetry fix can be reviewed independently.