### PR TITLE
Prime Sensirion BLE advertisement sample

### DIFF
--- a/CO2_Gadget_BLE.h
+++ b/CO2_Gadget_BLE.h
@@ -12,6 +12,21 @@ WifiMultiLibraryWrapper wifi;
 DataProvider provider(lib, DataType::T_RH_CO2, true, true, true, &wifi);
 #endif
 
+static inline bool writeSensirionCurrentSample() {
+#ifdef SUPPORT_BLE
+    if ((co2 < 400) || (co2 > 5000) || (temp < -40) || (temp > 85) || (hum < 0) || (hum > 100)) {
+        return false;
+    }
+
+    provider.writeValueToCurrentSample(co2, SignalType::CO2_PARTS_PER_MILLION);
+    provider.writeValueToCurrentSample(temp, SignalType::TEMPERATURE_DEGREES_CELSIUS);
+    provider.writeValueToCurrentSample(hum, SignalType::RELATIVE_HUMIDITY_PERCENTAGE);
+    return true;
+#else
+    return false;
+#endif
+}
+
 void setBLEHistoryInterval(uint64_t interval) {
 #ifdef SUPPORT_BLE
     if (provider.getHistoryInterval() != interval * 1000) {
@@ -36,7 +51,11 @@ void initBLE() {
             return;
         } else {
             setBLEHistoryInterval(sampleInterval);
+            bool initialSampleReady = writeSensirionCurrentSample();
             provider.begin();
+            if (initialSampleReady) {
+                provider.commitSample();
+            }
             Serial.print("-->[BLE ] Sensirion Gadget BLE Lib initialized with deviceId = ");
             Serial.println(provider.getDeviceIdString());
             Serial.print("-->[BLE ] History interval set to: ");
@@ -69,11 +88,10 @@ void publishBLE() {
     }
     if (millis() - lastMeasurementTimeMs >= measurementIntervalMs) {
         if ((activeBLE) && (co2 >= 400) && (co2 <= 5000) && (temp >= -40) && (temp <= 85) && (hum >= 0) && (hum <= 100) && thresholdsManager.evaluateThresholds(BLE_SEND, co2, temp, hum)) {
-            provider.writeValueToCurrentSample(co2, SignalType::CO2_PARTS_PER_MILLION);
-            provider.writeValueToCurrentSample(temp, SignalType::TEMPERATURE_DEGREES_CELSIUS);
-            provider.writeValueToCurrentSample(hum, SignalType::RELATIVE_HUMIDITY_PERCENTAGE);
-            provider.commitSample();
-            lastMeasurementTimeMs = millis();
+            if (writeSensirionCurrentSample()) {
+                provider.commitSample();
+                lastMeasurementTimeMs = millis();
+            }
         }
 #ifdef DEBUG_BLE
         Serial.println("-->[BLE ] Sent CO2: " + String(co2) + " ppm, Temp: " + String(temp) + " C, Hum: " + String(hum) + " %");


### PR DESCRIPTION
Write the current CO2, temperature, and humidity sample before starting the Sensirion BLE provider so the initial advertisement is populated after BLE init.

The existing validity checks only guarded the periodic BLE publish path. After deep sleep wake or BLE init, provider.begin() can start advertising before that publish path runs, which can expose stale, default, or invalid current-sample data in the first advertisement.

Add a shared helper that validates the CO2, temperature, and humidity ranges before writing the Sensirion current sample, and reuse it before normal BLE sample commits so both init and publish paths apply the same guard.