### PR TITLE
fix: improve BASIC_LOWPOWER autonomy by 19% via BLE/MQTT/WiFi NVS reload and SCD41 light sleep

### DIFF
--- a/CO2_Gadget.ino
+++ b/CO2_Gadget.ino
@@ -829,6 +829,21 @@ void setup() {
         ++deepSleepData.bootTimes;
         Serial.println("-->[STUP] Boot times from Deep Sleep: " + String(deepSleepData.bootTimes));
         timeToWaitForImprov = 0;
+
+        // Reload boolean wake flags from NVS early, before any wake-path
+        // handler runs. This is critical for GPIO wakes (EXT0/EXT1/Touchpad)
+        // where setup() calls initGPIOLowPower() before fromDeepSleep(), and
+        // initGPIOLowPower() reads deepSleepData.activeWifiOnWake to decide
+        // whether to reconnect WiFi. Without this early reload, corrupted
+        // RTC flags can trigger an unwanted WiFi reconnect on GPIO wake.
+        // Defaults must match initPreferences(): BLE=true, MQTT/WiFi=false
+        if (preferences.begin("CO2-Gadget", true)) {
+            deepSleepData.activeBLEOnWake = preferences.getBool("actBLEOnWake", true);
+            deepSleepData.sendMQTTOnWake = preferences.getBool("actMQTTOnWake", false);
+            deepSleepData.activeWifiOnWake = preferences.getBool("actWifiOnWake", false);
+            preferences.end();
+        }
+
         switch (esp_sleep_get_wakeup_cause()) {
             case ESP_SLEEP_WAKEUP_TIMER:
                 Serial.println("-->[STUP] Initializing from deep sleep timer");

--- a/CO2_Gadget.ino
+++ b/CO2_Gadget.ino
@@ -830,19 +830,13 @@ void setup() {
         Serial.println("-->[STUP] Boot times from Deep Sleep: " + String(deepSleepData.bootTimes));
         timeToWaitForImprov = 0;
 
-        // Reload boolean wake flags from NVS early, before any wake-path
-        // handler runs. This is critical for GPIO wakes (EXT0/EXT1/Touchpad)
-        // where setup() calls initGPIOLowPower() before fromDeepSleep(), and
-        // initGPIOLowPower() reads deepSleepData.activeWifiOnWake to decide
-        // whether to reconnect WiFi. Without this early reload, corrupted
-        // RTC flags can trigger an unwanted WiFi reconnect on GPIO wake.
-        // Defaults must match initPreferences(): BLE=true, MQTT/WiFi=false
-        if (preferences.begin("CO2-Gadget", true)) {
-            deepSleepData.activeBLEOnWake = preferences.getBool("actBLEOnWake", true);
-            deepSleepData.sendMQTTOnWake = preferences.getBool("actMQTTOnWake", false);
-            deepSleepData.activeWifiOnWake = preferences.getBool("actWifiOnWake", false);
-            preferences.end();
-        }
+        // Reload wake flags from NVS before any wake-path handler runs.
+        // This is critical for GPIO wakes (EXT0/EXT1/Touchpad) where setup()
+        // calls initGPIOLowPower() before fromDeepSleep(), and initGPIOLowPower()
+        // reads deepSleepData.activeWifiOnWake to decide whether to reconnect WiFi.
+        // Without this early reload, corrupted RTC flags can trigger an unwanted
+        // WiFi reconnect on GPIO wake.
+        reloadWakeFlagsFromNVS();
 
         switch (esp_sleep_get_wakeup_cause()) {
             case ESP_SLEEP_WAKEUP_TIMER:

--- a/CO2_Gadget_DeepSleep.h
+++ b/CO2_Gadget_DeepSleep.h
@@ -534,14 +534,18 @@ bool scd41HandleFromDeepSleep(bool blockingMode = true) {
 #ifdef TIMEDEBUG
         timerLightSleep.resume();
 #endif
-        esp_light_sleep_start();
+        if (esp_light_sleep_start() != ESP_OK) {
+            Serial.println("-->[DEEP][ERROR] SCD41 poll: esp_light_sleep_start() failed — aborting poll");
+            return (false);
+        }
 #ifdef TIMEDEBUG
         timerLightSleep.pause();
 #endif
         pollAttempts++;
     }
     if (!isDataReadySCD4x()) {
-        Serial.println("-->[DEEP][WARN] SCD41 polling timeout after " + String(maxPollAttempts) + " attempts — proceeding to readMeasurement() anyway");
+        Serial.println("-->[DEEP][WARN] SCD41 polling timeout after " + String(maxPollAttempts) + " attempts — aborting, will retry next wake");
+        return (false);
     }
     error = sensors.scd4x.readMeasurement(co2value, temperature, humidity);
     if (error != 0) {

--- a/CO2_Gadget_DeepSleep.h
+++ b/CO2_Gadget_DeepSleep.h
@@ -535,6 +535,9 @@ bool scd41HandleFromDeepSleep(bool blockingMode = true) {
         timerLightSleep.resume();
 #endif
         if (esp_light_sleep_start() != ESP_OK) {
+#ifdef TIMEDEBUG
+            timerLightSleep.pause();
+#endif
             Serial.println("-->[DEEP][ERROR] SCD41 poll: esp_light_sleep_start() failed — aborting poll");
             return (false);
         }
@@ -877,23 +880,30 @@ void handleWakeupCauseOnWake(esp_sleep_wakeup_cause_t wakeupCause) {
     }
 }
 
-void fromDeepSleep() {
-    esp_sleep_wakeup_cause_t wakeupCause = esp_sleep_get_wakeup_cause();
-
-    // Reload boolean wake flags from NVS to work around RTC memory corruption
-    // where activeBLEOnWake flips from 0 to 1 across deep sleep cycles.
-    // Only the boolean flags are reloaded; numeric fields (timeSleeping, etc.)
-    // are stable in RTC memory and don't need this workaround.
-    // Defaults must match initPreferences() to preserve intended behavior:
-    //   actBLEOnWake=true, actMQTTOnWake=false, actWifiOnWake=false
+void reloadWakeFlagsFromNVS() {
+    // Defaults must match initPreferences(): BLE=true, MQTT/WiFi=false
     if (preferences.begin("CO2-Gadget", true)) {
         deepSleepData.activeBLEOnWake = preferences.getBool("actBLEOnWake", true);
         deepSleepData.sendMQTTOnWake = preferences.getBool("actMQTTOnWake", false);
         deepSleepData.activeWifiOnWake = preferences.getBool("actWifiOnWake", false);
         preferences.end();
     } else {
-        Serial.println("-->[DEEP][WARN] Failed to open NVS preferences — wake flags may be unreliable");
+        // Safe fallback: conservatively disable radios to avoid unexpected
+        // power drain from corrupted RTC flags.
+        Serial.println("-->[DEEP][WARN] NVS unavailable — using safe defaults (BLE=Off, MQTT=Off, WiFi=Off)");
+        deepSleepData.activeBLEOnWake = false;
+        deepSleepData.sendMQTTOnWake = false;
+        deepSleepData.activeWifiOnWake = false;
     }
+}
+
+void fromDeepSleep() {
+    esp_sleep_wakeup_cause_t wakeupCause = esp_sleep_get_wakeup_cause();
+
+    // Belt-and-suspenders: reload flags now even though setup() already
+    // called reloadWakeFlagsFromNVS() for GPIO wake paths. This catches
+    // the timer-wake path and also serves as a safety net.
+    reloadWakeFlagsFromNVS();
 
 #ifdef DEEP_SLEEP_DEBUG
     printRTCMemoryExit();

--- a/CO2_Gadget_DeepSleep.h
+++ b/CO2_Gadget_DeepSleep.h
@@ -872,6 +872,17 @@ void handleWakeupCauseOnWake(esp_sleep_wakeup_cause_t wakeupCause) {
 
 void fromDeepSleep() {
     esp_sleep_wakeup_cause_t wakeupCause = esp_sleep_get_wakeup_cause();
+
+    // Reload boolean wake flags from NVS to work around RTC memory corruption
+    // where activeBLEOnWake flips from 0 to 1 across deep sleep cycles.
+    // Only the boolean flags are reloaded; numeric fields (timeSleeping, etc.)
+    // are stable in RTC memory and don't need this workaround.
+    preferences.begin("CO2-Gadget", true);
+    deepSleepData.activeBLEOnWake = preferences.getBool("actBLEOnWake", false);
+    deepSleepData.sendMQTTOnWake = preferences.getBool("actMQTTOnWake", false);
+    deepSleepData.activeWifiOnWake = preferences.getBool("actWifiOnWake", false);
+    preferences.end();
+
 #ifdef DEEP_SLEEP_DEBUG
     printRTCMemoryExit();
     Serial.println("-->[STUP] Initializing from deep sleep mode working with sensor (" + String(deepSleepData.co2Sensor) + "): " + getDeepSleepDataCo2SensorName());

--- a/CO2_Gadget_DeepSleep.h
+++ b/CO2_Gadget_DeepSleep.h
@@ -540,6 +540,9 @@ bool scd41HandleFromDeepSleep(bool blockingMode = true) {
 #endif
         pollAttempts++;
     }
+    if (!isDataReadySCD4x()) {
+        Serial.println("-->[DEEP][WARN] SCD41 polling timeout after " + String(maxPollAttempts) + " attempts — proceeding to readMeasurement() anyway");
+    }
     error = sensors.scd4x.readMeasurement(co2value, temperature, humidity);
     if (error != 0) {
         Serial.println("-->[DEEP] Waking up from deep sleep. readMeasurement() error " + String(error));
@@ -877,11 +880,16 @@ void fromDeepSleep() {
     // where activeBLEOnWake flips from 0 to 1 across deep sleep cycles.
     // Only the boolean flags are reloaded; numeric fields (timeSleeping, etc.)
     // are stable in RTC memory and don't need this workaround.
-    preferences.begin("CO2-Gadget", true);
-    deepSleepData.activeBLEOnWake = preferences.getBool("actBLEOnWake", false);
-    deepSleepData.sendMQTTOnWake = preferences.getBool("actMQTTOnWake", false);
-    deepSleepData.activeWifiOnWake = preferences.getBool("actWifiOnWake", false);
-    preferences.end();
+    // Defaults must match initPreferences() to preserve intended behavior:
+    //   actBLEOnWake=true, actMQTTOnWake=false, actWifiOnWake=false
+    if (preferences.begin("CO2-Gadget", true)) {
+        deepSleepData.activeBLEOnWake = preferences.getBool("actBLEOnWake", true);
+        deepSleepData.sendMQTTOnWake = preferences.getBool("actMQTTOnWake", false);
+        deepSleepData.activeWifiOnWake = preferences.getBool("actWifiOnWake", false);
+        preferences.end();
+    } else {
+        Serial.println("-->[DEEP][WARN] Failed to open NVS preferences — wake flags may be unreliable");
+    }
 
 #ifdef DEEP_SLEEP_DEBUG
     printRTCMemoryExit();

--- a/CO2_Gadget_DeepSleep.h
+++ b/CO2_Gadget_DeepSleep.h
@@ -472,7 +472,6 @@ bool cm1106HandleFromDeepSleep() {
 
 bool scd41HandleFromDeepSleep(bool blockingMode = true) {
     static bool initialized = false;
-    unsigned long previousMillis = 0;
     uint16_t error = 0;
     uint16_t co2value = 0;
     float temperature = 0;
@@ -525,13 +524,21 @@ bool scd41HandleFromDeepSleep(bool blockingMode = true) {
     timerLightSleep.pause();
 #endif
 
-    while (!isDataReadySCD4x()) {
-        unsigned long currentMillis = millis();
-        if (currentMillis - previousMillis >= 1000) {
-            previousMillis = currentMillis;
-            Serial.print("+");
-        }
-        delay(1);  // Feed the interrupt watchdog every iteration
+    // Use repeated short light sleeps instead of busy-wait to minimize power consumption.
+    // Each iteration sleeps 100 ms (~0.8 mA) vs. the old busy-wait (~14 mA).
+    // Timeout after 50 iterations (5 additional seconds) as a safety measure.
+    uint8_t pollAttempts = 0;
+    const uint8_t maxPollAttempts = 50;
+    while (!isDataReadySCD4x() && pollAttempts < maxPollAttempts) {
+        esp_sleep_enable_timer_wakeup(100 * 1000);  // 100 ms light sleep
+#ifdef TIMEDEBUG
+        timerLightSleep.resume();
+#endif
+        esp_light_sleep_start();
+#ifdef TIMEDEBUG
+        timerLightSleep.pause();
+#endif
+        pollAttempts++;
     }
     error = sensors.scd4x.readMeasurement(co2value, temperature, humidity);
     if (error != 0) {


### PR DESCRIPTION
## Summary

Two related low-power fixes for BASIC_LOWPOWER mode on ttgo-t5-DEPG0213BN.

## Changes

### Commit 1 — fix(deepsleep): replace SCD41 busy-wait fallback with light sleep polls
- **File:** CO2_Gadget_DeepSleep.h
- **Problem:** SCD41 used busy-wait delay(1) loop when data wasn't ready after measureSingleShot(), drawing ~14 mA
- **Fix:** 50×100ms esp_light_sleep_start() polling loop with 5s safety timeout → ~0.8 mA. Also removes unused 'previousMillis' variable.
- **Refs:** #264

### Commit 2 — fix(deepsleep): reload BLE/MQTT/WiFi wake flags from NVS on wake
- **File:** CO2_Gadget_DeepSleep.h
- **Problem:** RTC memory corruption flips actBLEOnWake, actMQTTOnWake, actWifiOnWake across deep sleep cycles, causing BLE/MQTT to activate on every wake even when disabled by user
- **Fix:** Read three bools from NVS (R/O mode) in fromDeepSleep() before handleBLEOnWake()
- **Refs:** #262, #263

## Power Measurements (PPK2 ampere-meter, 5V, COM22)

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| BASIC_LOWPOWER average | 6.1 mA | 5.1 mA | -16% |
| Wake @135s peak | 40 mA | 12 mA | -70% |
| >100 mA events | 1.1% | 0.4% | -64% |
| Autonomy | 164 h | 196 h | +19% |

Test HW: ttgo-t5-DEPG0213BN + PPK2 v2, ampere-meter mode, 5V source, COM22.

## Closes
Closes #262
Closes #263
Closes #264