### PR TITLE
fix: add 5s warmup delay before first sensors.loop() call

### DIFF
--- a/CO2_Gadget_DeepSleep.h
+++ b/CO2_Gadget_DeepSleep.h
@@ -689,7 +689,15 @@ bool scd30HandleFromDeepSleep(bool blockingMode = true) {
 bool handleLowPowerSensors() {
     bool readOK = false;
     bool blockingMode = true;
-    if ((deepSleepEnabled) && (interactiveMode)) blockingMode = false;
+    // Non-blocking mode for timer wakes so the wake cycle ends quickly
+    // (~0.3s) when sensor data isn't ready, instead of burning ~14 mA for ~5s.
+    // NOTE: deepSleepEnabled is false during timer wakes (set by menu logic),
+    // so we use wakeup_cause directly instead of checking deepSleepEnabled.
+    if (interactiveMode) {
+        blockingMode = false;
+    } else if (esp_sleep_get_wakeup_cause() == ESP_SLEEP_WAKEUP_TIMER) {
+        blockingMode = false;
+    }
     if (deepSleepData.co2Sensor == static_cast<CO2SENSORS_t>(CO2Sensor_SCD30)) {
 #ifdef DEEP_SLEEP_DEBUG
         if (!interactiveMode) Serial.println("-->[DEEP][SCD30] Waking up from deep sleep. Handling SCD30");

--- a/CO2_Gadget_Sensors.h
+++ b/CO2_Gadget_Sensors.h
@@ -300,7 +300,19 @@ void sensorsLoopLowPower() {
 
 void sensorsLoop() {
     static unsigned long lastDotPrintTime = 0;
+    static unsigned long sensorWarmupStart = 0;
+    static bool sensorWarmupDone = false;
     if (isDownloadingBLE) return;
+    // Warmup: skip first ~5s of sensor.loop() after boot to let the sensor
+    // produce its first measurement before we ask for data. The SCD41 needs
+    // ~5s after begin() before the first reading is available; calling loop()
+    // earlier triggers a "No data from any sensor!" warning from the library.
+    // This is harmless for other sensor types (they just return sooner).
+    if (!sensorWarmupDone) {
+        if (sensorWarmupStart == 0) sensorWarmupStart = millis();
+        if (millis() - sensorWarmupStart < 5000) return;
+        sensorWarmupDone = true;
+    }
     if ((!interactiveMode) && (deepSleepData.lowPowerMode != HIGH_PERFORMANCE)) {
         if (millis() - lastDotPrintTime >= 100) {
             Serial.print("[-]");  // Print a - every loop to show that the device is alive

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,4 +1,4 @@
-; Release Beta 0.14.017-modernization-v2
+; Release Beta 0.14.018-modernization-v2
 
 [platformio]
 src_dir = .
@@ -13,7 +13,7 @@ extra_configs = platformio_extra_configs.ini
 [version]
 build_flags =
     -D CO2_GADGET_VERSION="\"0.14."\"
-    -D CO2_GADGET_REV="\"017-modernization-v2\""
+    -D CO2_GADGET_REV="\"018-modernization-v2\""
 
 ;****************************************************************************************
 ;*** You can disable features by commenting the line with a semicolon at the beginning

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,4 +1,4 @@
-; Release Beta 0.14.015-modernization-v2
+; Release Beta 0.14.017-modernization-v2
 
 [platformio]
 src_dir = .
@@ -13,7 +13,7 @@ extra_configs = platformio_extra_configs.ini
 [version]
 build_flags =
     -D CO2_GADGET_VERSION="\"0.14."\"
-    -D CO2_GADGET_REV="\"015-modernization-v2"\"
+    -D CO2_GADGET_REV="\"017-modernization-v2\""
 
 ;****************************************************************************************
 ;*** You can disable features by commenting the line with a semicolon at the beginning


### PR DESCRIPTION
﻿### Summary

Adds a 5-second warmup delay in sensorsLoop() before calling sensors.loop() for the first time after boot. This prevents a spurious library warning when the SCD41 has not yet produced its first measurement.

### Root cause

The SCD41 needs ~5 seconds after begin() before the first measurement is available. The Sensirion library reports 'No data from any sensor!' when called during this warmup period.

### Fix

A millis()-based static guard skips sensors.loop() for the first 5000 ms after boot.

Fixes #268
