### PR TITLE
fix: call SCD41 wakeUp() on every deep sleep wake cycle

### DIFF
--- a/CO2_Gadget_DeepSleep.h
+++ b/CO2_Gadget_DeepSleep.h
@@ -495,9 +495,11 @@ bool scd41HandleFromDeepSleep(bool blockingMode = true) {
     Serial.println("() Interactive mode: " + String(interactiveMode) + " Blocking mode: " + String(blockingMode) + " Data ready: " + String(isDataReadySCD4x()));
 
     if ((!blockingMode) && (!isDataReadySCD4x()) && (!interactiveMode)) {
+        // Start a single-shot measurement without blocking so data is ready
+        // on the next wake cycle. Without this, the sensor never starts
+        // measuring in non-blocking mode, causing perpetual CO2: 0 readings.
+        sensors.scd4x.measureSingleShot(false);
         esp_sleep_enable_timer_wakeup(0.3 * 1000000);  // 0.3 seconds
-                                                       // Serial.println("-->[DEEP] Light sleep for 0.3 seconds");
-                                                       // Serial.flush();
 #ifdef TIMEDEBUG
         timerLightSleep.resume();
 #endif

--- a/CO2_Gadget_DeepSleep.h
+++ b/CO2_Gadget_DeepSleep.h
@@ -277,10 +277,12 @@ void toDeepSleep() {
     if (deepSleepData.co2Sensor == static_cast<CO2SENSORS_t>(CO2Sensor_SCD30)) {
         // sensors.scd30.stopContinuousMeasurement();
     } else if (deepSleepData.co2Sensor == static_cast<CO2SENSORS_t>(CO2Sensor_SCD41)) {
-        // SCD41 supports powerDown() (idle→sleep: ~0.5 mA → <0.1 mA).
-        // SCD40 does NOT support powerDown — use startLowPowerPeriodicMeasurement() instead.
+        // SCD41 supports powerDown() but it kills in-progress single-shot
+        // measurements started in non-blocking mode. Instead, leave the sensor
+        // in idle mode (~0.5 mA) so the measurement from measureSingleShot()
+        // can complete during the ESP32's deep sleep. The measurement takes
+        // ~5s vs ~30s deep sleep interval, so data is ready on next wake.
         sensors.scd4x.stopPeriodicMeasurement();
-        sensors.scd4x.powerDown();
     } else if ((deepSleepData.co2Sensor == static_cast<CO2SENSORS_t>(CO2Sensor_SCD40))) {
         sensors.scd4x.stopPeriodicMeasurement();
         sensors.scd4x.startLowPowerPeriodicMeasurement();

--- a/CO2_Gadget_DeepSleep.h
+++ b/CO2_Gadget_DeepSleep.h
@@ -471,22 +471,24 @@ bool cm1106HandleFromDeepSleep() {
 }
 
 bool scd41HandleFromDeepSleep(bool blockingMode = true) {
-    static bool initialized = false;
+    static bool i2cInitialized = false;
     uint16_t error = 0;
     uint16_t co2value = 0;
     float temperature = 0;
     float humidity = 0;
 
-    if (!initialized) {
+    if (!i2cInitialized) {
         reInitI2C();
         sensors.scd4x.begin(Wire);
-        // After powerDown() in toDeepSleep(), the SCD41 needs wakeUp() before any command.
-        // wakeUp() is intentionally NACK'd by the sensor (it is in sleep) — that is expected.
-        // The 20 ms delay is required per SCD41 datasheet before the next I2C command.
-        sensors.scd4x.wakeUp();
-        delay(20);
-        initialized = true;
+        i2cInitialized = true;
     }
+    // After powerDown() in toDeepSleep(), the SCD41 needs wakeUp() before any command.
+    // MUST be called on EVERY wake cycle, not just the first one — toDeepSleep()
+    // calls powerDown() before each deep sleep, leaving the sensor in sleep mode.
+    // wakeUp() is intentionally NACK'd by the sensor (it is in sleep) — that is expected.
+    // The 20 ms delay is required per SCD41 datasheet before the next I2C command.
+    sensors.scd4x.wakeUp();
+    delay(20);
 
     Serial.print("-->[DEEP] ");
     Serial.print(__func__);

--- a/CO2_Gadget_DeepSleep.h
+++ b/CO2_Gadget_DeepSleep.h
@@ -278,11 +278,12 @@ void toDeepSleep() {
         // sensors.scd30.stopContinuousMeasurement();
     } else if (deepSleepData.co2Sensor == static_cast<CO2SENSORS_t>(CO2Sensor_SCD41)) {
         // SCD41 supports powerDown() but it kills in-progress single-shot
-        // measurements started in non-blocking mode. Instead, leave the sensor
-        // in idle mode (~0.5 mA) so the measurement from measureSingleShot()
-        // can complete during the ESP32's deep sleep. The measurement takes
-        // ~5s vs ~30s deep sleep interval, so data is ready on next wake.
+        // measurements. Instead, leave the sensor in idle mode and start a
+        // non-blocking single-shot measurement that will complete during the
+        // ESP32's deep sleep (~5s vs ~30s interval). On next wake, data is
+        // already ready and can be read immediately.
         sensors.scd4x.stopPeriodicMeasurement();
+        sensors.scd4x.measureSingleShot(false);
     } else if ((deepSleepData.co2Sensor == static_cast<CO2SENSORS_t>(CO2Sensor_SCD40))) {
         sensors.scd4x.stopPeriodicMeasurement();
         sensors.scd4x.startLowPowerPeriodicMeasurement();

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,4 +1,4 @@
-; Release Beta 0.14.018-modernization-v2
+; Release Beta 0.14.019-modernization-v2
 
 [platformio]
 src_dir = .
@@ -13,7 +13,7 @@ extra_configs = platformio_extra_configs.ini
 [version]
 build_flags =
     -D CO2_GADGET_VERSION="\"0.14."\"
-    -D CO2_GADGET_REV="\"018-modernization-v2\""
+    -D CO2_GADGET_REV="\"019-modernization-v2\""
 
 ;****************************************************************************************
 ;*** You can disable features by commenting the line with a semicolon at the beginning


### PR DESCRIPTION
﻿### Summary

Calls SCD41 wakeUp() on every deep sleep wake cycle instead of only the first one.

### Root cause

toDeepSleep() calls powerDown() before every deep sleep entry. wakeUp() was inside a static bool guard that only ran on the first cycle, leaving the sensor in sleep mode on subsequent cycles. This caused I2C error 268 and CO2:0 readings.

### Fix

Separate I2C init (once) from wakeUp() + delay(20) (every cycle).

Fixes #271
