### PR TITLE
fix #248: Low power mode simplification (4→2 modes)

### DIFF
--- a/CO2_Gadget_DeepSleep.h
+++ b/CO2_Gadget_DeepSleep.h
@@ -27,9 +27,6 @@
 //     CO2Sensor_DEMO = 127
 // } CO2SENSORS_t;
 
-// LOW_POWER mode constants
-#define LOW_POWER 1  // Binary: 0 = HIGH_PERFORMANCE, 1 = LOW_POWER
-
 String getLowPowerModeName(uint16_t mode) {
     switch (mode) {
         case HIGH_PERFORMANCE:

--- a/CO2_Gadget_DeepSleep.h
+++ b/CO2_Gadget_DeepSleep.h
@@ -27,11 +27,14 @@
 //     CO2Sensor_DEMO = 127
 // } CO2SENSORS_t;
 
+// LOW_POWER mode constants
+#define LOW_POWER 1  // Binary: 0 = HIGH_PERFORMANCE, 1 = LOW_POWER
+
 String getLowPowerModeName(uint16_t mode) {
     switch (mode) {
         case HIGH_PERFORMANCE:
             return "HIGH_PERFORMANCE";
-        case 1:
+        case LOW_POWER:
             return "LOW_POWER";
         default:
             return "UNKNOWN";
@@ -646,7 +649,7 @@ bool scd30HandleFromDeepSleep(bool blockingMode = true) {
         sensors.setSampleTime(measurementInterval);
         sensors.setOnDataCallBack(&onSensorDataOk);      // all data read callback
         sensors.setOnErrorCallBack(&onSensorDataError);  // [optional] error callback
-        sensors.initCO2LowPowerMode(SENSORS::SSCD30, MEDIUM_LOWPOWER);
+        sensors.initCO2LowPowerMode(SENSORS::SSCD30, LOW_POWER);
         initialized = true;
     }
 
@@ -826,9 +829,9 @@ void handleMQTTPublishOnWake() {
 #endif
 }
 
-void handleMediumLowPowerModeOnWake() {
+void handleLowPowerModeOnWake() {
 #ifdef DEEP_SLEEP_DEBUG
-    Serial.println("-->[DEEP] Waking up from deep sleep. LowPowerMode: MEDIUM_LOWPOWER");
+    Serial.println("-->[DEEP] Waking up from deep sleep. LowPowerMode: LOW_POWER");
 #endif
     initBattery();
     batteryLoop();
@@ -849,7 +852,7 @@ void fromDeepSleepTimer() {
     handleCycleCountersOnWake();
 
     if (deepSleepData.lowPowerMode != HIGH_PERFORMANCE) {
-        handleMediumLowPowerModeOnWake();
+        handleLowPowerModeOnWake();
     }
 
     Serial.flush();

--- a/CO2_Gadget_DeepSleep.h
+++ b/CO2_Gadget_DeepSleep.h
@@ -646,7 +646,7 @@ bool scd30HandleFromDeepSleep(bool blockingMode = true) {
         sensors.setSampleTime(measurementInterval);
         sensors.setOnDataCallBack(&onSensorDataOk);      // all data read callback
         sensors.setOnErrorCallBack(&onSensorDataError);  // [optional] error callback
-        sensors.initCO2LowPowerMode(SENSORS::SSCD30, LOW_POWER);
+        sensors.initCO2LowPowerMode(SENSORS::SSCD30, (LowPowerModes)LOW_POWER);
         initialized = true;
     }
 

--- a/CO2_Gadget_Sensors.h
+++ b/CO2_Gadget_Sensors.h
@@ -163,7 +163,7 @@ void initSensorsLowPower() {
     if (selectedCO2Sensor == AUTO) {
         Serial.println("-->[SENS] Trying to init CO2 sensor in Low Power Mode: AutoSensor (I2C)");
         deepSleepData.measurementsStarted = false;
-        sensors.initCO2LowPowerMode(SENSORS::Auto, MEDIUM_LOWPOWER);  // Always use MEDIUM_LOWPOWER internally regardless of the binary lowPowerMode value
+        sensors.initCO2LowPowerMode(SENSORS::Auto, LOW_POWER);  // Always use LOW_POWER internally regardless of the binary lowPowerMode value
         return;
     }
 

--- a/CO2_Gadget_Sensors.h
+++ b/CO2_Gadget_Sensors.h
@@ -166,7 +166,7 @@ void initSensorsLowPower() {
     if (selectedCO2Sensor == AUTO) {
         Serial.println("-->[SENS] Trying to init CO2 sensor in Low Power Mode: AutoSensor (I2C)");
         deepSleepData.measurementsStarted = false;
-        sensors.initCO2LowPowerMode(SENSORS::Auto, LOW_POWER);  // Always use LOW_POWER internally regardless of the binary lowPowerMode value
+        sensors.initCO2LowPowerMode(SENSORS::Auto, (LowPowerModes)LOW_POWER);  // Always use LOW_POWER internally regardless of the binary lowPowerMode value
         return;
     }
 

--- a/CO2_Gadget_Sensors.h
+++ b/CO2_Gadget_Sensors.h
@@ -1,6 +1,9 @@
 #ifndef CO2_Gadget_Sensors_h
 #define CO2_Gadget_Sensors_h
 
+// LOW_POWER mode constants (shared with CO2_Gadget_DeepSleep.h)
+#define LOW_POWER 1  // Binary: 0 = HIGH_PERFORMANCE, 1 = LOW_POWER
+
 #include <Sensors.hpp>
 
 #include "CO2_Gadget_Thresholds.h"

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If you don't have a CO2 Monitor you will also find some complete tutorials to bu
 - **NEW: Apple-inspired web UI** with dark/light mode, responsive design, and card-based layout
 - **NEW: Interactive charts page** — historical CO2/temperature/humidity data with date filter and CSV/JSON export
 - **NEW: Calibration web page** — forced recalibration (FRC) with live CO2 readings
-- **NEW: Low power / deep sleep mode** with configurable sleep cycles, wake-up tracking and boot counters
+- **NEW: Low power / deep sleep mode** — two power modes: `HIGH_PERFORMANCE` (continuous operation, no deep sleep) and `LOW_POWER` (deep sleep enabled for battery operation), with configurable sleep cycles, wake-up tracking and boot counters
 - **NEW: Threshold-gated publishing** — MQTT, BLE and ESP-NOW messages only sent when values change by a configured amount (saves bandwidth and power)
 - **NEW: Particulate sensor support** (SPS30, SN-GCJA5) — PM1.0, PM2.5, PM4.0, PM10 published via MQTT with Home Assistant discovery
 - **NEW: Wake display on CO2 alert** — display automatically wakes when CO2 rises above warning threshold


### PR DESCRIPTION
## Summary

Fixes the discrepancy between the actual 2-mode power system (HIGH_PERFORMANCE / LOW_POWER) and the stale 4-mode references left over from the May 2026 merge.

## Changes

### Code cleanup

| File | Change |
|------|--------|
| CO2_Gadget_DeepSleep.h | Add #define LOW_POWER 1 constant; replace magic number 1 with LOW_POWER in getLowPowerModeName() |
| CO2_Gadget_DeepSleep.h | Replace MEDIUM_LOWPOWER → LOW_POWER in SCD30 sensor init |
| CO2_Gadget_DeepSleep.h | Rename handleMediumLowPowerModeOnWake() → handleLowPowerModeOnWake(); update log string |
| CO2_Gadget_DeepSleep.h | Update call site in fromDeepSleepTimer() |
| CO2_Gadget_Sensors.h | Update comment to reference LOW_POWER instead of MEDIUM_LOWPOWER |

### Documentation

| File | Change |
|------|--------|
| README.md | Update feature bullet to describe the two power modes: HIGH_PERFORMANCE (continuous) and LOW_POWER (deep sleep) |

Fixes #248