### PR TITLE
fix(deep-sleep): auto-enable WiFi when MQTT-on-wake is set

### DIFF
--- a/CO2_Gadget_DeepSleep.h
+++ b/CO2_Gadget_DeepSleep.h
@@ -391,6 +391,7 @@ bool isDataReadySCD4x() {
     return dataReadyFlag;
 }
 
+#ifdef SUPPORT_MQTT
 void doDeepSleepMQTTConnect() {
     if (WiFi.status() == WL_CONNECTED) {
         // Serial.printf("-->[DEEP] Initializing MQTT to broker IP: %s\n", mqttBroker.c_str());
@@ -408,6 +409,7 @@ void doDeepSleepMQTTConnect() {
         Serial.println("-->[DEEP][WARN] MQTT on wake skipped: WiFi not connected.");
     }
 }
+#endif // SUPPORT_MQTT
 
 void doDeepSleepWiFiConnect() {
     initPreferences();

--- a/CO2_Gadget_DeepSleep.h
+++ b/CO2_Gadget_DeepSleep.h
@@ -404,6 +404,8 @@ void doDeepSleepMQTTConnect() {
             Serial.print("-->[DEEP] rootTopic: ");
             Serial.println(rootTopic);
         }
+    } else {
+        Serial.println("-->[DEEP][WARN] MQTT on wake skipped: WiFi not connected.");
     }
 }
 

--- a/CO2_Gadget_Menu.h
+++ b/CO2_Gadget_Menu.h
@@ -199,6 +199,20 @@ result doSavePreferences(eventMask e, navNode &nav, prompt &item) {
     Serial.println(e);
     Serial.flush();
 #endif
+    // MQTT on wake requires WiFi on wake — auto-enable WiFi if MQTT is set
+    if (deepSleepData.sendMQTTOnWake && !deepSleepData.activeWifiOnWake) {
+        Serial.println();
+        Serial.println("-->[MENU] WARNING: MQTT on wake requires WiFi on wake.");
+        Serial.println("-->[MENU] Enabling WiFi on wake automatically.");
+        Serial.println();
+        deepSleepData.activeWifiOnWake = true;
+    }
+    // ESP-NOW on wake also requires WiFi on wake (for MQTT transport once implemented)
+    if (deepSleepData.sendESPNowOnWake && !deepSleepData.activeWifiOnWake) {
+        Serial.println();
+        Serial.println("-->[MENU] WARNING: ESP-NOW on wake requires WiFi on wake.");
+        Serial.println();
+    }
     putPreferences();
     return quit;
 }

--- a/CO2_Gadget_Preferences.h
+++ b/CO2_Gadget_Preferences.h
@@ -443,6 +443,15 @@ void saveWifiCredentials() {
 
 void putPreferences() {
     Serial.println("-->[PREF] Saving preferences to NVR");
+    // MQTT on wake requires WiFi on wake — auto-enable WiFi if MQTT is set.
+    // This catches ALL save paths: menu, serial, and web UI (which calls putPreferences() directly).
+    if (deepSleepData.sendMQTTOnWake && !deepSleepData.activeWifiOnWake) {
+        Serial.println();
+        Serial.println("-->[PREF] WARNING: MQTT on wake requires WiFi on wake.");
+        Serial.println("-->[PREF] Enabling WiFi on wake automatically.");
+        Serial.println();
+        deepSleepData.activeWifiOnWake = true;
+    }
     rootTopic.trim();
     mqttClientId.trim();
     mqttBroker.trim();

--- a/platformio.ini
+++ b/platformio.ini
@@ -13,7 +13,7 @@ extra_configs = platformio_extra_configs.ini
 [version]
 build_flags =
     -D CO2_GADGET_VERSION="\"0.15."\"
-    -D CO2_GADGET_REV="\"015002-modernization-v2\""
+    -D CO2_GADGET_REV="\"015.002-modernization-v2\""
 
 ;****************************************************************************************
 ;*** You can disable features by commenting the line with a semicolon at the beginning

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,4 +1,4 @@
-; Release Beta 0.14.019-modernization-v2
+; Release Beta 0.15.001-modernization-v2
 
 [platformio]
 src_dir = .
@@ -7,13 +7,13 @@ lib_dir = libs
 ; build_dir = ${sysenv.TEMP}/pio-build/$PROJECT_HASH
 default_envs = esp32dev, esp32dev_OLED, TTGO_TDISPLAY, TTGO_TDISPLAY_SANDWICH, TDISPLAY_S3, ttgo-t5-EINKBOARDDEPG0213BN, ttgo-t5-EINKBOARDGDEW0213M21, ttgo-t7-EINKBOARDGDEM029T94 ; Default environments to build
 name = CO2 Gadget
-description = An easy to build CO2 Monitor/Meter with Android and iOS App for real time visualization and charting of air data, data logger, a variety of communication options (BLE, WIFI, MQTT, ESP-Now) and many supported sensors.
+description = An easy to build CO2 Monitor/Meter with Android and iOS App for real time visualization and charting of air data, data logger, a variety of communication options (BLE, WIFI, MQTT, ESP-NOW) and many supported sensors.
 extra_configs = platformio_extra_configs.ini
 
 [version]
 build_flags =
-    -D CO2_GADGET_VERSION="\"0.14."\"
-    -D CO2_GADGET_REV="\"019-modernization-v2\""
+    -D CO2_GADGET_VERSION="\"0.15."\"
+    -D CO2_GADGET_REV="\"015002-modernization-v2\""
 
 ;****************************************************************************************
 ;*** You can disable features by commenting the line with a semicolon at the beginning

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,4 +1,4 @@
-; Release Beta 0.15.001-modernization-v2
+; Release Beta 0.15.002-modernization-v2
 
 [platformio]
 src_dir = .


### PR DESCRIPTION
## Summary

When `sendMQTTOnWake = true` but `activeWifiOnWake = false`, MQTT publications silently never happen during deep sleep wake cycles.

## Root Cause

`doDeepSleepWiFiConnect()` only calls `connectToWiFi()` when `activeWifiOnWake` is true, but calls `doDeepSleepMQTTConnect()` regardless. When `activeWifiOnWake` is false, `WiFi.status()` is never `WL_CONNECTED` and MQTT silently fails.

## Changes

| File | Change |
|------|--------|
| `CO2_Gadget_Preferences.h` | MQTT+WiFi consistency check in `putPreferences()` — auto-enables `activeWifiOnWake` when `sendMQTTOnWake` is set. Catches ALL paths (menu, serial, web UI). |
| `CO2_Gadget_DeepSleep.h` | Diagnostic log when MQTT skipped due to no WiFi. `#ifdef SUPPORT_MQTT` guard on `doDeepSleepMQTTConnect()`. |
| `CO2_Gadget_Menu.h` | Removed misleading ESP-NOW warning. |

## Copilot Review Comments Addressed

1. Moved fix from `doSavePreferences()` to `putPreferences()` to cover web UI save path
2. Removed misleading ESP-NOW warning (`initESPNow()` is independent of `activeWifiOnWake`)
3. Added `#ifdef SUPPORT_MQTT` guard around `doDeepSleepMQTTConnect()`

## Verification

- End-to-end verified on hardware (ESP32 DEPG0213BN, COM6)
- POST `actWifiOnWake=false` + `actMQTTOnWake=true` → `putPreferences()` auto-set `activeWifiOnWake=true`
- Next wake cycle: WiFi connected, MQTT published measurements successfully

Closes #276