### PR TITLE
Enhance calibration behaviour deep sleep

### DIFF
--- a/CO2_Gadget.ino
+++ b/CO2_Gadget.ino
@@ -54,6 +54,7 @@ uint64_t getReliableUptimeSeconds();                // Accumulated uptime across
 String getReliableUptimeFormatted();                // Accumulated uptime formatted as <dd>d <hh>h <mm>m
 void restartTimerToDeepSleep();                     // Defined in CO2_Gadget_DeepSleep.h
 void toDeepSleep();                                 // Defined in CO2_Gadget_DeepSleep.h
+void processPendingCommands();                      // Defined below; called from CO2_Gadget_DeepSleep.h wake path
 void setDisplayReverse(bool reverse);               // Defined in CO2_Gadget_TFT.h or CO2_Gadget_OLED.h or CO2_Gadget_EINK.h
 void setDisplayBrightness(uint16_t newBrightness);  // Defined in CO2_Gadget_TFT.h or CO2_Gadget_OLED.h
 
@@ -235,6 +236,14 @@ typedef struct {
     uint64_t uptimeMillis;
     bool lastWifiRSSIValid;
     int16_t lastWifiRSSI;
+    // Pending calibration / ambient pressure carried across deep sleep so a
+    // command received during a brief wake window is applied on the next wake
+    // instead of being lost with volatile RAM.
+    // See: https://github.com/melkati/CO2-Gadget/issues/250
+    bool calibrateOnNextWake;
+    uint16_t pendingCalibrationValue;
+    bool setAmbientPressureOnNextWake;
+    uint16_t pendingAmbientPressureValue;
 } deepSleepData_t;
 
 RTC_DATA_ATTR deepSleepData_t deepSleepData;
@@ -482,6 +491,7 @@ void processPendingCommands() {
             Serial.println("-->[MAIN] Calibrating CO2 sensor at " + String(calibrationValue) + " PPM");
             pendingCalibration = false;
             sensors.setCO2RecalibrationFactor(calibrationValue);
+            saveCalibrationValue();  // Persist so the value survives reboot. See: https://github.com/melkati/CO2-Gadget/issues/250
         } else {
             Serial.println("-->[MAIN] Avoiding calibrating CO2 sensor with invalid value at " + String(calibrationValue) + " PPM");
             pendingCalibration = false;

--- a/CO2_Gadget.ino
+++ b/CO2_Gadget.ino
@@ -257,6 +257,7 @@ typedef struct {
     uint16_t calTargetPpm;       // reference ppm to calibrate to
     uint16_t calReadingsSeen;    // readings since the sequence began (the first is discarded)
     uint32_t calStartUptimeSec;  // reliable uptime when the sequence began (min-time gate)
+    bool calForceContinuous;     // pause deep sleep for sensors needing continuous operation (CM1106)
     bool setAmbientPressureOnNextWake;
     uint16_t pendingAmbientPressureValue;
 } deepSleepData_t;
@@ -524,6 +525,24 @@ void beginCalibrationSequence(uint16_t ppm) {
         Serial.println("-->[CAL] Ignoring calibration request: invalid value " + String(ppm) + " ppm");
         return;
     }
+    // CM1106 re-inits its driver and toggles CM1106_ENABLE_PIN on each deep-sleep
+    // wake, so it is not guaranteed to stay continuously powered/measuring while a
+    // warm-up spans sleeps — and its field calibration needs continuous operation.
+    // Instead of refusing, pause deep sleep for the duration of the calibration so
+    // the sensor runs continuously, then resume deep sleep when it completes (flag
+    // cleared in advanceCalibrationSequence()). SCD30/SCD4x stay powered across
+    // sleep (and SCD4x's one-shot-per-wake warm-up matches the datasheet), so they
+    // keep calibrating across wakes. See: https://github.com/melkati/CO2-Gadget/issues/250
+    bool isCm1106 = (deepSleepData.co2Sensor == CO2Sensor_CM1106) ||
+                    (deepSleepData.co2Sensor == CO2Sensor_CM1106SL_NS);
+    deepSleepData.calForceContinuous = (isCm1106 && (deepSleepData.lowPowerMode != HIGH_PERFORMANCE));
+    if (deepSleepData.calForceContinuous) {
+        Serial.println("-->[CAL] CM1106 needs continuous operation: pausing deep sleep until calibration completes.");
+        // Ensure the sensor is in continuous measurement mode so sensors.loop() yields readings.
+        if (sensors.isSensorRegistered(SENSORS::SCM1106)) {
+            sensors.cm1106->set_working_status(CM1106_CONTINUOUS_MEASUREMENT);
+        }
+    }
     deepSleepData.calPhase = CAL_WARMUP;
     deepSleepData.calTargetPpm = ppm;
     deepSleepData.calReadingsSeen = 0;
@@ -556,6 +575,7 @@ void advanceCalibrationSequence() {
     sensors.setCO2RecalibrationFactor(calibrationValue);
     saveCalibrationValue();  // persist so the value survives reboot. See issue #250
     deepSleepData.calPhase = CAL_IDLE;
+    deepSleepData.calForceContinuous = false;  // resume deep sleep if it was paused for this calibration
     Serial.println("-->[CAL] Calibration command sent and value persisted.");
 }
 
@@ -598,10 +618,11 @@ void readingsLoop() {
         if (newReadingsAvailable) {
             lastReadingsCommunicationTime = esp_timer_get_time();
             newReadingsAvailable = false;
-            // Advance any calibration warm-up on each fresh reading. Gated to
-            // high-performance mode; in low power the deep-sleep wake handler
-            // advances it once per wake. See issue #250.
-            if (deepSleepData.lowPowerMode == HIGH_PERFORMANCE) advanceCalibrationSequence();
+            // Advance any calibration warm-up on each fresh reading. Fires in
+            // high-performance mode and while a calibration has paused deep sleep
+            // (CM1106 forced-continuous); in normal low power the deep-sleep wake
+            // handler advances it once per wake instead. See issue #250.
+            if ((deepSleepData.lowPowerMode == HIGH_PERFORMANCE) || deepSleepData.calForceContinuous) advanceCalibrationSequence();
             nav.idleChanged = true;  // Must redraw display as there are new readings
 #ifdef SUPPORT_CIRCULAR_BUFFER
             addCO2Value(co2);

--- a/CO2_Gadget.ino
+++ b/CO2_Gadget.ino
@@ -55,6 +55,8 @@ String getReliableUptimeFormatted();                // Accumulated uptime format
 void restartTimerToDeepSleep();                     // Defined in CO2_Gadget_DeepSleep.h
 void toDeepSleep();                                 // Defined in CO2_Gadget_DeepSleep.h
 void processPendingCommands();                      // Defined below; called from CO2_Gadget_DeepSleep.h wake path
+void beginCalibrationSequence(uint16_t ppm);        // Defined below; starts the warm-up sequence
+void advanceCalibrationSequence();                  // Defined below; advances one warm-up reading (also called on wake)
 void setDisplayReverse(bool reverse);               // Defined in CO2_Gadget_TFT.h or CO2_Gadget_OLED.h or CO2_Gadget_EINK.h
 void setDisplayBrightness(uint16_t newBrightness);  // Defined in CO2_Gadget_TFT.h or CO2_Gadget_OLED.h
 
@@ -207,6 +209,17 @@ typedef enum {
     CO2Sensor_DEMO = 127
 } CO2SENSORS_t;
 
+// Calibration warm-up sequence phase (stored in RTC, survives deep sleep).
+// See: https://github.com/melkati/CO2-Gadget/issues/250
+enum CalPhase : uint8_t { CAL_IDLE = 0, CAL_WARMUP = 1 };
+
+// Per-sensor warm-up requirement before a field calibration may be applied.
+struct CalWarmup {
+    uint16_t minReadings;  // usable readings required (excludes the discarded first)
+    uint16_t minSeconds;   // minimum elapsed warm-up time
+};
+CalWarmup getCalWarmup();  // Defined after the sensor includes; used by the web status endpoints too
+
 // LOW POWER MODES
 // typedef enum LowPowerMode { HIGH_PERFORMANCE, BASIC_LOWPOWER, MEDIUM_LOWPOWER, MAXIMUM_LOWPOWER };
 
@@ -236,12 +249,14 @@ typedef struct {
     uint64_t uptimeMillis;
     bool lastWifiRSSIValid;
     int16_t lastWifiRSSI;
-    // Pending calibration / ambient pressure carried across deep sleep so a
-    // command received during a brief wake window is applied on the next wake
-    // instead of being lost with volatile RAM.
-    // See: https://github.com/melkati/CO2-Gadget/issues/250
-    bool calibrateOnNextWake;
-    uint16_t pendingCalibrationValue;
+    // Calibration warm-up sequence + pending ambient pressure, carried across deep
+    // sleep so a calibration runs the datasheet-required warm-up (collect N readings
+    // over a minimum time, discarding the first) even when that warm-up spans
+    // several low-power wake cycles. See: https://github.com/melkati/CO2-Gadget/issues/250
+    uint8_t calPhase;            // CalPhase: CAL_IDLE / CAL_WARMUP
+    uint16_t calTargetPpm;       // reference ppm to calibrate to
+    uint16_t calReadingsSeen;    // readings since the sequence began (the first is discarded)
+    uint32_t calStartUptimeSec;  // reliable uptime when the sequence began (min-time gate)
     bool setAmbientPressureOnNextWake;
     uint16_t pendingAmbientPressureValue;
 } deepSleepData_t;
@@ -484,17 +499,76 @@ void wakeUpDisplay() {
     return;
 }
 
+// ---- Datasheet-compliant calibration warm-up sequence ----------------------
+// Field calibration on these sensors is only valid after the sensor has been
+// measuring in a stable, homogeneous CO2 environment for a sensor-specific
+// warm-up, and the first reading after start-up must be discarded. In low-power
+// mode the warm-up spans several deep-sleep wakes, so progress lives in RTC
+// (deepSleepData) and advances one reading at a time.
+// See: https://github.com/melkati/CO2-Gadget/issues/250
+CalWarmup getCalWarmup() {
+    switch (deepSleepData.co2Sensor) {
+        case CO2Sensor_SCD40:
+        case CO2Sensor_SCD41:        return {5, 180};   // >3 min / 5 single shots (SCD4x Low Power Operation)
+        case CO2Sensor_SCD30:        return {4, 120};   // >2 min continuous (SCD30 interface description)
+        case CO2Sensor_MHZ19:        return {3, 1200};  // ~20 min at 400 ppm before zero-point calibration
+        case CO2Sensor_CM1106:
+        case CO2Sensor_CM1106SL_NS:  return {3, 120};   // warm-up before start_calibration()
+        case CO2Sensor_SENSEAIRS8:   return {3, 120};   // fresh-air exposure, then background manual_calibration()
+        default:                     return {1, 0};     // DEMO / NONE: immediate (for testing)
+    }
+}
+
+void beginCalibrationSequence(uint16_t ppm) {
+    if (ppm > 2000) {
+        Serial.println("-->[CAL] Ignoring calibration request: invalid value " + String(ppm) + " ppm");
+        return;
+    }
+    deepSleepData.calPhase = CAL_WARMUP;
+    deepSleepData.calTargetPpm = ppm;
+    deepSleepData.calReadingsSeen = 0;
+    deepSleepData.calStartUptimeSec = (uint32_t)getReliableUptimeSeconds();
+    CalWarmup w = getCalWarmup();
+    Serial.println("-->[CAL] Starting calibration to " + String(ppm) + " ppm. Warm-up needs " +
+                   String(w.minReadings) + " readings over >=" + String(w.minSeconds) + " s (first reading discarded).");
+}
+
+// Advance the warm-up by one fresh sensor reading. Called once per reading:
+// from readingsLoop() in high-performance mode and from the deep-sleep wake
+// handler in low-power mode (one reading per wake).
+void advanceCalibrationSequence() {
+    if (deepSleepData.calPhase != CAL_WARMUP) return;
+    deepSleepData.calReadingsSeen++;
+    if (deepSleepData.calReadingsSeen == 1) {
+        Serial.println("-->[CAL] Warm-up: discarding first reading after start.");
+        return;
+    }
+    CalWarmup w = getCalWarmup();
+    uint16_t usable = deepSleepData.calReadingsSeen - 1;  // first reading is discarded
+    uint32_t elapsed = (uint32_t)getReliableUptimeSeconds() - deepSleepData.calStartUptimeSec;
+    Serial.println("-->[CAL] Warm-up: reading " + String(usable) + "/" + String(w.minReadings) +
+                   ", elapsed " + String(elapsed) + "/" + String(w.minSeconds) + " s (CO2 " + String(co2) + " ppm)");
+    if (usable < w.minReadings || elapsed < w.minSeconds) return;
+
+    // Warm-up satisfied: issue the sensor-specific recalibration now.
+    Serial.println("-->[CAL] Warm-up complete. Calibrating sensor to " + String(deepSleepData.calTargetPpm) + " ppm.");
+    calibrationValue = deepSleepData.calTargetPpm;
+    sensors.setCO2RecalibrationFactor(calibrationValue);
+    saveCalibrationValue();  // persist so the value survives reboot. See issue #250
+    deepSleepData.calPhase = CAL_IDLE;
+    Serial.println("-->[CAL] Calibration command sent and value persisted.");
+}
+
 void processPendingCommands() {
     if (isDownloadingBLE) return;
     if (pendingCalibration == true) {
-        if ((calibrationValue >= 0) && (calibrationValue <= 2000)) {
-            Serial.println("-->[MAIN] Calibrating CO2 sensor at " + String(calibrationValue) + " PPM");
-            pendingCalibration = false;
-            sensors.setCO2RecalibrationFactor(calibrationValue);
-            saveCalibrationValue();  // Persist so the value survives reboot. See: https://github.com/melkati/CO2-Gadget/issues/250
+        pendingCalibration = false;
+        // Don't calibrate immediately — start the datasheet warm-up sequence, which
+        // collects/discards readings (across wakes in low power) before recalibrating.
+        if (calibrationValue <= 2000) {
+            if (deepSleepData.calPhase == CAL_IDLE) beginCalibrationSequence(calibrationValue);
         } else {
             Serial.println("-->[MAIN] Avoiding calibrating CO2 sensor with invalid value at " + String(calibrationValue) + " PPM");
-            pendingCalibration = false;
         }
     }
 
@@ -524,6 +598,10 @@ void readingsLoop() {
         if (newReadingsAvailable) {
             lastReadingsCommunicationTime = esp_timer_get_time();
             newReadingsAvailable = false;
+            // Advance any calibration warm-up on each fresh reading. Gated to
+            // high-performance mode; in low power the deep-sleep wake handler
+            // advances it once per wake. See issue #250.
+            if (deepSleepData.lowPowerMode == HIGH_PERFORMANCE) advanceCalibrationSequence();
             nav.idleChanged = true;  // Must redraw display as there are new readings
 #ifdef SUPPORT_CIRCULAR_BUFFER
             addCO2Value(co2);

--- a/CO2_Gadget.ino
+++ b/CO2_Gadget.ino
@@ -593,13 +593,31 @@ void processPendingCommands() {
     }
 
     if (pendingAmbientPressure == true) {
+        pendingAmbientPressure = false;
         if (ambientPressureValue != 0) {
-            Serial.println("-->[MAIN] Setting AmbientPressure for CO2 sensor at " + String(ambientPressureValue) + " mbar\n");
-            pendingAmbientPressure = false;
-            // sensors.scd30.setAmbientPressure(ambientPressureValue); To-Do: Implement after migration to sensorlib 0.7.3
+            // Ambient pressure (mbar == hPa) enables continuous pressure compensation
+            // and overrides altitude-based compensation. Only the Sensirion CO2 sensors
+            // support it. See: https://github.com/melkati/CO2-Gadget/issues/250
+            Serial.println("-->[MAIN] Setting ambient pressure for CO2 sensor to " + String(ambientPressureValue) + " mbar");
+            bool isScd4x = (deepSleepData.co2Sensor == CO2Sensor_SCD40) ||
+                           (deepSleepData.co2Sensor == CO2Sensor_SCD41);
+            bool isScd30 = (deepSleepData.co2Sensor == CO2Sensor_SCD30);
+            if (isScd4x && sensors.isSensorRegistered(SENSORS::SSCD4X)) {
+                // SCD4x takes hPa (== mbar) and accepts it during periodic measurement.
+                uint16_t err = sensors.scd4x.setAmbientPressure(ambientPressureValue);
+                if (err) Serial.println("-->[MAIN][ERROR] SCD4x setAmbientPressure error: " + String(err));
+            } else if (isScd30 && sensors.isSensorRegistered(SENSORS::SSCD30)) {
+                // SCD30 sets pressure by (re)starting continuous measurement; valid 700-1400 mbar.
+                if ((ambientPressureValue >= 700) && (ambientPressureValue <= 1400)) {
+                    sensors.scd30.startContinuousMeasurement(ambientPressureValue);
+                } else {
+                    Serial.println("-->[MAIN] SCD30 ambient pressure out of range (700-1400 mbar); ignoring " + String(ambientPressureValue));
+                }
+            } else {
+                Serial.println("-->[MAIN] Ambient pressure compensation not supported for the active sensor; ignoring.");
+            }
         } else {
-            Serial.println("-->[MAIN] Avoiding setting AmbientPressure for CO2 sensor with invalid value at " + String(ambientPressureValue) + " mbar\n");
-            pendingAmbientPressure = false;
+            Serial.println("-->[MAIN] Avoiding setting ambient pressure with invalid value (0 mbar)");
         }
     }
 }

--- a/CO2_Gadget.ino
+++ b/CO2_Gadget.ino
@@ -253,7 +253,7 @@ typedef struct {
     // sleep so a calibration runs the datasheet-required warm-up (collect N readings
     // over a minimum time, discarding the first) even when that warm-up spans
     // several low-power wake cycles. See: https://github.com/melkati/CO2-Gadget/issues/250
-    uint8_t calPhase;            // CalPhase: CAL_IDLE / CAL_WARMUP
+    uint8_t calPhase;            // CalPhase: CAL_IDLE / CAL_WARMUP (set by beginCalibrationSequence)
     uint16_t calTargetPpm;       // reference ppm to calibrate to
     uint16_t calReadingsSeen;    // readings since the sequence began (the first is discarded)
     uint32_t calStartUptimeSec;  // reliable uptime when the sequence began (min-time gate)
@@ -521,8 +521,10 @@ CalWarmup getCalWarmup() {
 }
 
 void beginCalibrationSequence(uint16_t ppm) {
-    if (ppm > 2000) {
-        Serial.println("-->[CAL] Ignoring calibration request: invalid value " + String(ppm) + " ppm");
+    // Reject implausible targets: fresh air is ~400-430 ppm, so a value below 400 (or
+    // 0) is not a valid calibration reference. Matches the menu's 400-2000 ppm range.
+    if ((ppm < 400) || (ppm > 2000)) {
+        Serial.println("-->[CAL] Ignoring calibration request: invalid value " + String(ppm) + " ppm (valid 400-2000)");
         return;
     }
     // CM1106 re-inits its driver and toggles CM1106_ENABLE_PIN on each deep-sleep
@@ -585,8 +587,12 @@ void processPendingCommands() {
         pendingCalibration = false;
         // Don't calibrate immediately — start the datasheet warm-up sequence, which
         // collects/discards readings (across wakes in low power) before recalibrating.
-        if (calibrationValue <= 2000) {
-            if (deepSleepData.calPhase == CAL_IDLE) beginCalibrationSequence(calibrationValue);
+        if ((calibrationValue >= 400) && (calibrationValue <= 2000)) {
+            if (deepSleepData.calPhase == CAL_IDLE) {
+                beginCalibrationSequence(calibrationValue);
+            } else {
+                Serial.println("-->[MAIN] Calibration already in progress (warming up to " + String(deepSleepData.calTargetPpm) + " ppm); ignoring new request for " + String(calibrationValue) + " PPM");
+            }
         } else {
             Serial.println("-->[MAIN] Avoiding calibrating CO2 sensor with invalid value at " + String(calibrationValue) + " PPM");
         }

--- a/CO2_Gadget_DeepSleep.h
+++ b/CO2_Gadget_DeepSleep.h
@@ -386,13 +386,23 @@ void toDeepSleep() {
     // processPendingCommands()), kick it off now so the warm-up resumes on the next
     // wake; the sequence state itself lives in RTC and survives sleep.
     // See: https://github.com/melkati/CO2-Gadget/issues/250
-    if (pendingCalibration && (deepSleepData.calPhase == CAL_IDLE) && (calibrationValue <= 2000)) {
+    if (pendingCalibration && (deepSleepData.calPhase == CAL_IDLE) && (calibrationValue >= 400) && (calibrationValue <= 2000)) {
         beginCalibrationSequence(calibrationValue);
     }
     pendingCalibration = false;
     if (pendingAmbientPressure) {
         deepSleepData.setAmbientPressureOnNextWake = true;
         deepSleepData.pendingAmbientPressureValue = ambientPressureValue;
+    }
+
+    // If the calibration just started needs continuous operation (CM1106 in low
+    // power), don't sleep now — that would defeat the pause. Abort so the sensor
+    // stays awake and measures continuously; deepSleepLoop() keeps the device awake
+    // while calForceContinuous is set, and deep sleep resumes once calibration
+    // completes. See: https://github.com/melkati/CO2-Gadget/issues/250
+    if (deepSleepData.calForceContinuous) {
+        Serial.println("-->[DEEP] Aborting deep sleep: calibration needs continuous operation.");
+        return;
     }
 
     gpio_deep_sleep_hold_en();

--- a/CO2_Gadget_DeepSleep.h
+++ b/CO2_Gadget_DeepSleep.h
@@ -854,17 +854,29 @@ void handleLowPowerModeOnWake() {
     if (handleLowPowerSensors()) {
         // Apply a calibration / ambient pressure command that was queued before
         // sleep, now that the sensor is awake and has produced a fresh reading.
-        // Restore the volatile RAM flags from RTC and reuse processPendingCommands()
-        // so range validation and the actual sensor calls live in one place.
-        // NOTE: for SCD40/SCD41 the FRC offset is stored in volatile registers and
-        // is wiped by the next scd4x.begin()/reinit() — so this is best-effort for
-        // the current wake cycle only; ASC (autoSelfCalibration) is the durable
-        // path for SCD4x once the canairio_sensorlib fork exposes it.
+        // Restore the RAM flags from RTC and reuse processPendingCommands() so
+        // range validation and the actual sensor calls live in one place.
         // See: https://github.com/melkati/CO2-Gadget/issues/250
         if (deepSleepData.calibrateOnNextWake) {
-            pendingCalibration = true;
-            calibrationValue = deepSleepData.pendingCalibrationValue;
-            deepSleepData.calibrateOnNextWake = false;
+            bool isScd4x = (deepSleepData.co2Sensor == static_cast<CO2SENSORS_t>(CO2Sensor_SCD40)) ||
+                           (deepSleepData.co2Sensor == static_cast<CO2SENSORS_t>(CO2Sensor_SCD41));
+            if (isScd4x) {
+                // SCD4x forced recalibration (FRC) requires >3 min of prior
+                // measurement (Sensirion app note "SCD4x Low Power Operation"),
+                // which a single wake-shot cannot provide — the command would
+                // return 0xffff and the library leaves the sensor in periodic
+                // mode, fighting the single-shot-idle deep-sleep flow. The value
+                // is already persisted; calibrate the SCD4x in interactive mode
+                // (sensor runs periodic long enough) or enable Auto Self-Cal.
+                Serial.println("-->[DEEP][WARN] Skipping on-wake FRC for SCD4x (needs >3 min warm-up). Calibrate interactively or enable ASC.");
+                deepSleepData.calibrateOnNextWake = false;
+            } else {
+                // SCD30/MH-Z19/CM1106/S8 store calibration in their own
+                // non-volatile memory and accept recalibration immediately.
+                pendingCalibration = true;
+                calibrationValue = deepSleepData.pendingCalibrationValue;
+                deepSleepData.calibrateOnNextWake = false;
+            }
         }
         if (deepSleepData.setAmbientPressureOnNextWake) {
             pendingAmbientPressure = true;

--- a/CO2_Gadget_DeepSleep.h
+++ b/CO2_Gadget_DeepSleep.h
@@ -289,6 +289,21 @@ void toDeepSleep() {
         sensors.scd4x.startLowPowerPeriodicMeasurement();
     }
 
+    // Carry any still-pending calibration / ambient pressure command into RTC
+    // memory so it survives deep sleep and is applied on the next wake. Without
+    // this, a command set in RAM during the wake window (web/BLE/MQTT) is lost
+    // before processPendingCommands() ever runs, because that only executes in
+    // loop()/loopOLD(), never in the deep-sleep wake path.
+    // See: https://github.com/melkati/CO2-Gadget/issues/250
+    if (pendingCalibration) {
+        deepSleepData.calibrateOnNextWake = true;
+        deepSleepData.pendingCalibrationValue = calibrationValue;
+    }
+    if (pendingAmbientPressure) {
+        deepSleepData.setAmbientPressureOnNextWake = true;
+        deepSleepData.pendingAmbientPressureValue = ambientPressureValue;
+    }
+
     Serial.println("");
     Serial.println("-->***********************************************************************************");
     Serial.println("-->[DEEP] Going into deep sleep for " + String(deepSleepData.timeSleeping) + " seconds with LowPowerMode: " + String(deepSleepData.lowPowerMode) + " (" + getLowPowerModeName(deepSleepData.lowPowerMode) + ")");
@@ -837,6 +852,26 @@ void handleLowPowerModeOnWake() {
     initBattery();
     batteryLoop();
     if (handleLowPowerSensors()) {
+        // Apply a calibration / ambient pressure command that was queued before
+        // sleep, now that the sensor is awake and has produced a fresh reading.
+        // Restore the volatile RAM flags from RTC and reuse processPendingCommands()
+        // so range validation and the actual sensor calls live in one place.
+        // NOTE: for SCD40/SCD41 the FRC offset is stored in volatile registers and
+        // is wiped by the next scd4x.begin()/reinit() — so this is best-effort for
+        // the current wake cycle only; ASC (autoSelfCalibration) is the durable
+        // path for SCD4x once the canairio_sensorlib fork exposes it.
+        // See: https://github.com/melkati/CO2-Gadget/issues/250
+        if (deepSleepData.calibrateOnNextWake) {
+            pendingCalibration = true;
+            calibrationValue = deepSleepData.pendingCalibrationValue;
+            deepSleepData.calibrateOnNextWake = false;
+        }
+        if (deepSleepData.setAmbientPressureOnNextWake) {
+            pendingAmbientPressure = true;
+            ambientPressureValue = deepSleepData.pendingAmbientPressureValue;
+            deepSleepData.setAmbientPressureOnNextWake = false;
+        }
+        processPendingCommands();
         displayFromDeepSleep(deepSleepData.cyclesLeftToRedrawDisplay == 0);
     }
     handleBLEOnWake();

--- a/CO2_Gadget_DeepSleep.h
+++ b/CO2_Gadget_DeepSleep.h
@@ -376,19 +376,20 @@ void toDeepSleep() {
     esp_sleep_pd_config(ESP_PD_DOMAIN_VDDSDIO, ESP_PD_OPTION_OFF);
 #endif
 
-    // Capture any still-pending calibration / ambient pressure command into RTC
-    // memory as the LAST step before sleep — AFTER prepareServicesForDeepSleep()
-    // has torn down WiFi/BLE/MQTT. Those handlers run in their own FreeRTOS tasks
-    // and can set pendingCalibration at any moment while the radios are up, so
-    // capturing earlier would race: a command arriving between the capture and
-    // esp_deep_sleep_start() would be lost with volatile RAM. processPendingCommands()
-    // applies it while the device is awake; this only catches the late, about-to-
-    // sleep case. With the radios down here, the flag can no longer change.
+    // Handle any still-pending command as the LAST step before sleep — AFTER
+    // prepareServicesForDeepSleep() has torn down WiFi/BLE/MQTT. Those handlers run
+    // in their own FreeRTOS tasks and can set pendingCalibration at any moment while
+    // the radios are up, so doing this earlier would race: a command arriving between
+    // here and esp_deep_sleep_start() would be lost with volatile RAM. With the radios
+    // down, the flag can no longer change. If a calibration was requested but its
+    // warm-up sequence hasn't started yet (the command landed too late for
+    // processPendingCommands()), kick it off now so the warm-up resumes on the next
+    // wake; the sequence state itself lives in RTC and survives sleep.
     // See: https://github.com/melkati/CO2-Gadget/issues/250
-    if (pendingCalibration) {
-        deepSleepData.calibrateOnNextWake = true;
-        deepSleepData.pendingCalibrationValue = calibrationValue;
+    if (pendingCalibration && (deepSleepData.calPhase == CAL_IDLE) && (calibrationValue <= 2000)) {
+        beginCalibrationSequence(calibrationValue);
     }
+    pendingCalibration = false;
     if (pendingAmbientPressure) {
         deepSleepData.setAmbientPressureOnNextWake = true;
         deepSleepData.pendingAmbientPressureValue = ambientPressureValue;
@@ -855,32 +856,12 @@ void handleLowPowerModeOnWake() {
     initBattery();
     batteryLoop();
     if (handleLowPowerSensors()) {
-        // Apply a calibration / ambient pressure command that was queued before
-        // sleep, now that the sensor is awake and has produced a fresh reading.
-        // Restore the RAM flags from RTC and reuse processPendingCommands() so
-        // range validation and the actual sensor calls live in one place.
+        // This wake produced one fresh sensor reading — advance any in-progress
+        // calibration warm-up by one step (collect/discard across wakes; the
+        // sensor-specific recalibration fires once the warm-up is satisfied).
+        // The sequence state lives in RTC, so it resumes seamlessly across sleeps.
         // See: https://github.com/melkati/CO2-Gadget/issues/250
-        if (deepSleepData.calibrateOnNextWake) {
-            bool isScd4x = (deepSleepData.co2Sensor == static_cast<CO2SENSORS_t>(CO2Sensor_SCD40)) ||
-                           (deepSleepData.co2Sensor == static_cast<CO2SENSORS_t>(CO2Sensor_SCD41));
-            if (isScd4x) {
-                // SCD4x forced recalibration (FRC) requires >3 min of prior
-                // measurement (Sensirion app note "SCD4x Low Power Operation"),
-                // which a single wake-shot cannot provide — the command would
-                // return 0xffff and the library leaves the sensor in periodic
-                // mode, fighting the single-shot-idle deep-sleep flow. The value
-                // is already persisted; calibrate the SCD4x in interactive mode
-                // (sensor runs periodic long enough) or enable Auto Self-Cal.
-                Serial.println("-->[DEEP][WARN] Skipping on-wake FRC for SCD4x (needs >3 min warm-up). Calibrate interactively or enable ASC.");
-                deepSleepData.calibrateOnNextWake = false;
-            } else {
-                // SCD30/MH-Z19/CM1106/S8 store calibration in their own
-                // non-volatile memory and accept recalibration immediately.
-                pendingCalibration = true;
-                calibrationValue = deepSleepData.pendingCalibrationValue;
-                deepSleepData.calibrateOnNextWake = false;
-            }
-        }
+        advanceCalibrationSequence();
         if (deepSleepData.setAmbientPressureOnNextWake) {
             pendingAmbientPressure = true;
             ambientPressureValue = deepSleepData.pendingAmbientPressureValue;

--- a/CO2_Gadget_DeepSleep.h
+++ b/CO2_Gadget_DeepSleep.h
@@ -972,6 +972,15 @@ void deepSleepLoop() {
     // if (deepSleepData.lowPowerMode == HIGH_PERFORMANCE) return;
     if (!deepSleepEnabled) return;
 
+    // A calibration on a sensor that needs continuous operation (CM1106) has paused
+    // deep sleep; keep the device awake until the warm-up + recalibration finishes.
+    // advanceCalibrationSequence() clears the flag on completion, so sleep resumes.
+    // See: https://github.com/melkati/CO2-Gadget/issues/250
+    if (deepSleepData.calForceContinuous) {
+        restartTimerToDeepSleep();
+        return;
+    }
+
 #ifdef DEEP_SLEEP_DEBUG
         // Serial.println("-->[DEEP] inMenu: " + String(inMenu));
 #endif

--- a/CO2_Gadget_DeepSleep.h
+++ b/CO2_Gadget_DeepSleep.h
@@ -289,21 +289,6 @@ void toDeepSleep() {
         sensors.scd4x.startLowPowerPeriodicMeasurement();
     }
 
-    // Carry any still-pending calibration / ambient pressure command into RTC
-    // memory so it survives deep sleep and is applied on the next wake. Without
-    // this, a command set in RAM during the wake window (web/BLE/MQTT) is lost
-    // before processPendingCommands() ever runs, because that only executes in
-    // loop()/loopOLD(), never in the deep-sleep wake path.
-    // See: https://github.com/melkati/CO2-Gadget/issues/250
-    if (pendingCalibration) {
-        deepSleepData.calibrateOnNextWake = true;
-        deepSleepData.pendingCalibrationValue = calibrationValue;
-    }
-    if (pendingAmbientPressure) {
-        deepSleepData.setAmbientPressureOnNextWake = true;
-        deepSleepData.pendingAmbientPressureValue = ambientPressureValue;
-    }
-
     Serial.println("");
     Serial.println("-->***********************************************************************************");
     Serial.println("-->[DEEP] Going into deep sleep for " + String(deepSleepData.timeSleeping) + " seconds with LowPowerMode: " + String(deepSleepData.lowPowerMode) + " (" + getLowPowerModeName(deepSleepData.lowPowerMode) + ")");
@@ -390,6 +375,24 @@ void toDeepSleep() {
 #if CONFIG_IDF_TARGET_ESP32
     esp_sleep_pd_config(ESP_PD_DOMAIN_VDDSDIO, ESP_PD_OPTION_OFF);
 #endif
+
+    // Capture any still-pending calibration / ambient pressure command into RTC
+    // memory as the LAST step before sleep — AFTER prepareServicesForDeepSleep()
+    // has torn down WiFi/BLE/MQTT. Those handlers run in their own FreeRTOS tasks
+    // and can set pendingCalibration at any moment while the radios are up, so
+    // capturing earlier would race: a command arriving between the capture and
+    // esp_deep_sleep_start() would be lost with volatile RAM. processPendingCommands()
+    // applies it while the device is awake; this only catches the late, about-to-
+    // sleep case. With the radios down here, the flag can no longer change.
+    // See: https://github.com/melkati/CO2-Gadget/issues/250
+    if (pendingCalibration) {
+        deepSleepData.calibrateOnNextWake = true;
+        deepSleepData.pendingCalibrationValue = calibrationValue;
+    }
+    if (pendingAmbientPressure) {
+        deepSleepData.setAmbientPressureOnNextWake = true;
+        deepSleepData.pendingAmbientPressureValue = ambientPressureValue;
+    }
 
     gpio_deep_sleep_hold_en();
     // adc_oneshot_del_unit(adc_handle); // TO-DO: Check if this is needed measuring current consumption in deep sleep

--- a/CO2_Gadget_Preferences.h
+++ b/CO2_Gadget_Preferences.h
@@ -171,6 +171,7 @@ void printActualSettings() {
     Serial.println("-->[PREF] firmBranch:\t #" + firmBranch + "#");
     Serial.println("-->[PREF] firmFlavour:\t #" + firmFlavour + "#");
     Serial.println("-->[PREF] customCalValue: #" + String(customCalibrationValue) + "#");
+    Serial.println("-->[PREF] calValue:\t #" + String(calibrationValue) + "#");
     Serial.println("-->[PREF] tempOffset:\t #" + String(tempOffset, 1) + "#");
     Serial.println("-->[PREF] altitudeMeters:\t #" + String(altitudeMeters) + "#");
     Serial.println("-->[PREF] autoSelfCalibration:\t #" + String(autoSelfCalibration ? "Enabled" : "Disabled") + "#");
@@ -298,6 +299,7 @@ void initPreferences() {
     firmBranch = preferences.getString("firmBranch", "");
     firmFlavour = preferences.getString("firmFlavour", "");
     customCalibrationValue = preferences.getUInt("customCalValue", 415);
+    calibrationValue = preferences.getUInt("calValue", 415);  // See: https://github.com/melkati/CO2-Gadget/issues/250
     tempOffset = float(preferences.getFloat("tempOffset", 0));
     altitudeMeters = preferences.getUInt("altitudeMeters", 0);
     autoSelfCalibration = preferences.getBool("autoSelfCal", false);
@@ -441,6 +443,18 @@ void saveWifiCredentials() {
     preferences.end();
 }
 
+// Persist only the active calibration value, so a calibration applied during a
+// deep-sleep wake cycle (which never calls the full putPreferences()) still
+// survives a reboot. Calibration is a rare user action, so flash wear is
+// negligible. See: https://github.com/melkati/CO2-Gadget/issues/250
+void saveCalibrationValue() {
+    preferences.begin("CO2-Gadget", false);
+    if (preferences.getUInt("calValue", 415) != calibrationValue) {
+        preferences.putUInt("calValue", calibrationValue);
+    }
+    preferences.end();
+}
+
 void putPreferences() {
     Serial.println("-->[PREF] Saving preferences to NVR");
     // MQTT on wake requires WiFi on wake — auto-enable WiFi if MQTT is set.
@@ -469,6 +483,7 @@ void putPreferences() {
     preferences.putString("firmBranch", firmBranch);
     preferences.putString("firmFlavour", firmFlavour);
     preferences.putUInt("customCalValue", customCalibrationValue);
+    preferences.putUInt("calValue", calibrationValue);  // See: https://github.com/melkati/CO2-Gadget/issues/250
     preferences.putFloat("tempOffset", tempOffset);
     preferences.putUInt("altitudeMeters", altitudeMeters);
     preferences.putBool("autoSelfCal", autoSelfCalibration);
@@ -593,6 +608,7 @@ String getActualSettingsAsJson(bool includePasswords = false) {
     doc["firmBranch"] = getCO2GadgetRevisionBranch();
     doc["firmFlavour"] = FLAVOUR;
     doc["customCalValue"] = customCalibrationValue;
+    doc["calValue"] = calibrationValue;  // See: https://github.com/melkati/CO2-Gadget/issues/250
     doc["tempOffset"] = String(tempOffset, 1);
     doc["altitudeMeters"] = altitudeMeters;
     doc["autoSelfCal"] = autoSelfCalibration;
@@ -735,6 +751,9 @@ bool handleSavePreferencesFromJSON(String jsonPreferences) {
 
         if (JsonDocument.containsKey("customCalValue")) {
             customCalibrationValue = JsonDocument["customCalValue"];
+        }
+        if (JsonDocument.containsKey("calValue")) {  // See: https://github.com/melkati/CO2-Gadget/issues/250
+            calibrationValue = JsonDocument["calValue"];
         }
         if (JsonDocument.containsKey("tempOffset") && (tempOffset != float(JsonDocument["tempOffset"]))) {
             Serial.println("-->[PREF] Temp Offset changed from " + String(tempOffset) + " to " + String(JsonDocument["tempOffset"].as<String>()));

--- a/CO2_Gadget_Sensors.h
+++ b/CO2_Gadget_Sensors.h
@@ -321,13 +321,13 @@ void sensorsLoop() {
         if (millis() - sensorWarmupStart < 5000) return;
         sensorWarmupDone = true;
     }
-    if ((!interactiveMode) && (deepSleepData.lowPowerMode != HIGH_PERFORMANCE)) {
+    if ((!interactiveMode) && (deepSleepData.lowPowerMode != HIGH_PERFORMANCE) && (!deepSleepData.calForceContinuous)) {
         if (millis() - lastDotPrintTime >= 100) {
             Serial.print("[-]");  // Print a - every loop to show that the device is alive
             lastDotPrintTime = millis();
         }
         sensorsLoopLowPower();
-    } else if (!buzzerBeeping) {  // Avoid affecting beep sound
+    } else if (!buzzerBeeping) {  // Avoid affecting beep sound (also continuous reads while a calibration paused deep sleep)
         // if (millis() - lastDotPrintTime >= 100) {
         //     Serial.print("[+] ");        // Print a + every loop to show that the device is alive
         //     lastDotPrintTime = millis();

--- a/CO2_Gadget_Sensors.h
+++ b/CO2_Gadget_Sensors.h
@@ -196,7 +196,12 @@ void initSensors() {
     sensors.setDebugMode(debugSensors);              // [optional] debug mode
     sensors.setTempOffset(tempOffset);
     sensors.setCO2AltitudeOffset(altitudeMeters);
-    // sensors.setAutoSelfCalibration(false); // TO-DO: Implement in CanAirIO Sensors Lib
+    // Auto self-calibration (ASC for SCD30/SCD4x, ABC for MH-Z19) is sensor-specific.
+    // The sleep interval is passed so the library can scale SCD4x ASC periods for the
+    // single-shot idle interval (default periods assume 5-min sampling): scale by
+    // 5 / (timeSleeping / 60). TODO: enable once the canairio_sensorlib fork exposes
+    // setAutoSelfCalibration(bool, uint16_t). See: https://github.com/melkati/CO2-Gadget/issues/250
+    // sensors.setAutoSelfCalibration(autoSelfCalibration, deepSleepData.timeSleeping);
     sensors.setSampleTime(measurementInterval);
 
     Serial.println("-->[SENS] Selected CO2 Sensor: " + sensors.getSensorName(static_cast<SENSORS>(selectedCO2Sensor)));

--- a/CO2_Gadget_Sensors.h
+++ b/CO2_Gadget_Sensors.h
@@ -196,12 +196,6 @@ void initSensors() {
     sensors.setDebugMode(debugSensors);              // [optional] debug mode
     sensors.setTempOffset(tempOffset);
     sensors.setCO2AltitudeOffset(altitudeMeters);
-    // Auto self-calibration (ASC for SCD30/SCD4x, ABC for MH-Z19) is sensor-specific.
-    // The sleep interval is passed so the library can scale SCD4x ASC periods for the
-    // single-shot idle interval (default periods assume 5-min sampling): scale by
-    // 5 / (timeSleeping / 60). TODO: enable once the canairio_sensorlib fork exposes
-    // setAutoSelfCalibration(bool, uint16_t). See: https://github.com/melkati/CO2-Gadget/issues/250
-    // sensors.setAutoSelfCalibration(autoSelfCalibration, deepSleepData.timeSleeping);
     sensors.setSampleTime(measurementInterval);
 
     Serial.println("-->[SENS] Selected CO2 Sensor: " + sensors.getSensorName(static_cast<SENSORS>(selectedCO2Sensor)));
@@ -250,6 +244,15 @@ void initSensors() {
             sensors.init(SENSEAIRS8);
         }
     }
+
+    // Apply auto self-calibration now that the sensor is detected/registered (ASC for
+    // SCD30/SCD4x, ABC for MH-Z19). Done here, not before detection, so the library's
+    // isSensorRegistered() checks see the sensor. The sleep interval lets the library
+    // scale the SCD4x ASC periods for the single-shot idle interval (default periods
+    // assume 5-min sampling). initSensors() runs on cold boot / mode entry only —
+    // deep-sleep wakes go through fromDeepSleep() and the ASC setting persists in the
+    // sensor. See: https://github.com/melkati/CO2-Gadget/issues/250
+    sensors.setAutoSelfCalibration(autoSelfCalibration, deepSleepData.timeSleeping);
 
     printSensorsDetected();
     storeSensorSelectedInRTC();

--- a/CO2_Gadget_WIFI.h
+++ b/CO2_Gadget_WIFI.h
@@ -929,7 +929,7 @@ String getCO2GadgetStatusAsJson() {
     // Calibration state (sensor-aware). See: https://github.com/melkati/CO2-Gadget/issues/250
     doc["customCalibrationValue"] = customCalibrationValue;
     doc["autoSelfCalibration"] = autoSelfCalibration;
-    doc["calibrateOnNextWake"] = deepSleepData.calibrateOnNextWake;
+    doc["calibrationInProgress"] = (deepSleepData.calPhase != CAL_IDLE);
     doc["ambientPressureValue"] = ambientPressureValue;
     doc["pendingAmbientPressure"] = pendingAmbientPressure;
     doc["freeHeap"] = ESP.getFreeHeap();
@@ -963,12 +963,19 @@ String getCalibrationStatusAsJson() {
     doc["calibrationValue"] = calibrationValue;
     doc["customCalibrationValue"] = customCalibrationValue;
     doc["pendingCalibration"] = pendingCalibration;
-    doc["calibrateOnNextWake"] = deepSleepData.calibrateOnNextWake;
     doc["autoSelfCalibration"] = autoSelfCalibration;
     doc["ambientPressureValue"] = ambientPressureValue;
     doc["pendingAmbientPressure"] = pendingAmbientPressure;
-    // Derived per-sensor facts (see getCalibrationTraits): lets the UI warn that,
-    // e.g., an SCD4x will not retain a forced recalibration across deep sleep.
+    // Live warm-up sequence progress so the UI shows real state, not a static note.
+    CalWarmup w = getCalWarmup();
+    bool calibrating = (deepSleepData.calPhase != CAL_IDLE);
+    uint16_t usableReadings = (deepSleepData.calReadingsSeen > 0) ? (deepSleepData.calReadingsSeen - 1) : 0;
+    doc["calibrationInProgress"] = calibrating;
+    doc["calibrationTargetPpm"] = deepSleepData.calTargetPpm;
+    doc["warmupReadings"] = usableReadings;
+    doc["warmupReadingsRequired"] = w.minReadings;
+    doc["warmupSecondsRequired"] = w.minSeconds;
+    // Derived per-sensor facts (see getCalibrationTraits).
     doc["calibrationRetainedAcrossReboot"] = traits.retainedAcrossReboot;
     doc["autoSelfCalibrationSupported"] = traits.autoSelfCalSupported;
 

--- a/CO2_Gadget_WIFI.h
+++ b/CO2_Gadget_WIFI.h
@@ -971,6 +971,7 @@ String getCalibrationStatusAsJson() {
     bool calibrating = (deepSleepData.calPhase != CAL_IDLE);
     uint16_t usableReadings = (deepSleepData.calReadingsSeen > 0) ? (deepSleepData.calReadingsSeen - 1) : 0;
     doc["calibrationInProgress"] = calibrating;
+    doc["calibrationPausedDeepSleep"] = deepSleepData.calForceContinuous;
     doc["calibrationTargetPpm"] = deepSleepData.calTargetPpm;
     doc["warmupReadings"] = usableReadings;
     doc["warmupReadingsRequired"] = w.minReadings;

--- a/CO2_Gadget_WIFI.h
+++ b/CO2_Gadget_WIFI.h
@@ -836,8 +836,12 @@ String getCO2GadgetFeaturesAsJson() {
 
 // Calibration characteristics of the active CO2 sensor, so the web UI can show
 // real per-sensor state instead of a static "pending" note.
-//  - retainedAcrossReboot: does the sensor keep its calibration through a power cycle?
-//    (SCD4x stores the FRC offset in volatile registers -> false; others -> true)
+//  - retainedAcrossReboot: does the sensor keep its calibration through power loss?
+//    All supported sensors store calibration in their own non-volatile memory, so
+//    this is true across the board. (SCD4x is also never power-cycled or reinit'd
+//    in deep sleep here — toDeepSleep() keeps it in single-shot idle and
+//    SensirionI2CScd4x::begin() sends no command — so its FRC correction also
+//    survives every wake; FRC/ASC history is stored in the SCD4x EEPROM.)
 //  - autoSelfCalSupported: does the sensor support auto self-calibration (ASC/ABC)?
 // See: https://github.com/melkati/CO2-Gadget/issues/250
 struct CalibrationTraits {
@@ -848,13 +852,10 @@ struct CalibrationTraits {
 CalibrationTraits getCalibrationTraits() {
     CalibrationTraits t = {false, false};
     switch (deepSleepData.co2Sensor) {
-        case CO2Sensor_SCD30:        // FRAM (non-volatile); native ASC
-            t.retainedAcrossReboot = true;  t.autoSelfCalSupported = true;  break;
+        case CO2Sensor_SCD30:        // non-volatile calibration; native ASC
         case CO2Sensor_SCD40:
-        case CO2Sensor_SCD41:        // volatile FRC offset; ASC viable in single-shot idle
-            t.retainedAcrossReboot = false; t.autoSelfCalSupported = true;  break;
+        case CO2Sensor_SCD41:        // EEPROM FRC/ASC history; ASC viable in single-shot idle
         case CO2Sensor_MHZ19:        // EEPROM; ABC supported (currently hard-disabled)
-            t.retainedAcrossReboot = true;  t.autoSelfCalSupported = true;  break;
         case CO2Sensor_CM1106:
         case CO2Sensor_CM1106SL_NS:  // internal memory; ABC on (7-day)
         case CO2Sensor_SENSEAIRS8:   // internal memory; ABC on (180-hour)

--- a/CO2_Gadget_WIFI.h
+++ b/CO2_Gadget_WIFI.h
@@ -834,8 +834,39 @@ String getCO2GadgetFeaturesAsJson() {
     return output;
 }
 
+// Calibration characteristics of the active CO2 sensor, so the web UI can show
+// real per-sensor state instead of a static "pending" note.
+//  - retainedAcrossReboot: does the sensor keep its calibration through a power cycle?
+//    (SCD4x stores the FRC offset in volatile registers -> false; others -> true)
+//  - autoSelfCalSupported: does the sensor support auto self-calibration (ASC/ABC)?
+// See: https://github.com/melkati/CO2-Gadget/issues/250
+struct CalibrationTraits {
+    bool retainedAcrossReboot;
+    bool autoSelfCalSupported;
+};
+
+CalibrationTraits getCalibrationTraits() {
+    CalibrationTraits t = {false, false};
+    switch (deepSleepData.co2Sensor) {
+        case CO2Sensor_SCD30:        // FRAM (non-volatile); native ASC
+            t.retainedAcrossReboot = true;  t.autoSelfCalSupported = true;  break;
+        case CO2Sensor_SCD40:
+        case CO2Sensor_SCD41:        // volatile FRC offset; ASC viable in single-shot idle
+            t.retainedAcrossReboot = false; t.autoSelfCalSupported = true;  break;
+        case CO2Sensor_MHZ19:        // EEPROM; ABC supported (currently hard-disabled)
+            t.retainedAcrossReboot = true;  t.autoSelfCalSupported = true;  break;
+        case CO2Sensor_CM1106:
+        case CO2Sensor_CM1106SL_NS:  // internal memory; ABC on (7-day)
+        case CO2Sensor_SENSEAIRS8:   // internal memory; ABC on (180-hour)
+            t.retainedAcrossReboot = true;  t.autoSelfCalSupported = true;  break;
+        default:                     // DEMO / NONE
+            t.retainedAcrossReboot = false; t.autoSelfCalSupported = false; break;
+    }
+    return t;
+}
+
 String getCO2GadgetStatusAsJson() {
-    StaticJsonDocument<512> doc;
+    JsonDocument doc;  // elastic (ArduinoJson v7); avoids fixed-pool truncation as fields grow
     doc["mainDeviceSelected"] = mainDeviceSelected;
     doc["CO2"] = co2;
     doc["Temperature"] = String(temp, 2);
@@ -894,6 +925,12 @@ String getCO2GadgetStatusAsJson() {
     doc["sampleInterval"] = sampleInterval;
     doc["calibrationValue"] = calibrationValue;
     doc["pendingCalibration"] = pendingCalibration;
+    // Calibration state (sensor-aware). See: https://github.com/melkati/CO2-Gadget/issues/250
+    doc["customCalibrationValue"] = customCalibrationValue;
+    doc["autoSelfCalibration"] = autoSelfCalibration;
+    doc["calibrateOnNextWake"] = deepSleepData.calibrateOnNextWake;
+    doc["ambientPressureValue"] = ambientPressureValue;
+    doc["pendingAmbientPressure"] = pendingAmbientPressure;
     doc["freeHeap"] = ESP.getFreeHeap();
     doc["minFreeHeap"] = ESP.getMinFreeHeap();
     doc["uptime"] = millis();
@@ -909,6 +946,30 @@ String getCO2GadgetStatusAsJson() {
     doc["actMQTTOnWake"] = deepSleepData.sendMQTTOnWake;
     doc["actESPnowWake"] = deepSleepData.sendESPNowOnWake;
     doc["displayOnWake"] = deepSleepData.displayOnWake;
+
+    String output;
+    serializeJson(doc, output);
+    return output;
+}
+
+// Focused, sensor-aware calibration status for the web UI to poll, so it can
+// show real calibration state instead of a static "Calibration pending" note.
+// See: https://github.com/melkati/CO2-Gadget/issues/250
+String getCalibrationStatusAsJson() {
+    JsonDocument doc;
+    CalibrationTraits traits = getCalibrationTraits();
+    doc["sensor"] = mainDeviceSelected;
+    doc["calibrationValue"] = calibrationValue;
+    doc["customCalibrationValue"] = customCalibrationValue;
+    doc["pendingCalibration"] = pendingCalibration;
+    doc["calibrateOnNextWake"] = deepSleepData.calibrateOnNextWake;
+    doc["autoSelfCalibration"] = autoSelfCalibration;
+    doc["ambientPressureValue"] = ambientPressureValue;
+    doc["pendingAmbientPressure"] = pendingAmbientPressure;
+    // Derived per-sensor facts (see getCalibrationTraits): lets the UI warn that,
+    // e.g., an SCD4x will not retain a forced recalibration across deep sleep.
+    doc["calibrationRetainedAcrossReboot"] = traits.retainedAcrossReboot;
+    doc["autoSelfCalibrationSupported"] = traits.autoSelfCalSupported;
 
     String output;
     serializeJson(doc, output);
@@ -1667,6 +1728,16 @@ void initWebServer() {
         if (request != nullptr) {
             String statusJson = getCO2GadgetStatusAsJson();
             request->send(200, "application/json", statusJson);
+        } else {
+            Serial.println("---> [WiFi] Error: request is null");
+        }
+    });
+
+    // Sensor-aware calibration status. See: https://github.com/melkati/CO2-Gadget/issues/250
+    server.on("/getCalibrationStatus", HTTP_GET, [](AsyncWebServerRequest *request) {
+        if (request != nullptr) {
+            String calibrationJson = getCalibrationStatusAsJson();
+            request->send(200, "application/json", calibrationJson);
         } else {
             Serial.println("---> [WiFi] Error: request is null");
         }


### PR DESCRIPTION
## Summary

This addresses the calibration problems reported in #250.

In low-power mode the main `loop()` barely runs — each wake handles the cycle and the device goes back to deep sleep — so the existing calibration path, which only runs from `loop()`/`loopOLD()`, never executed reliably. A calibration sent over WiFi/BLE/MQTT during a short wake window was held in plain RAM and lost on the next sleep, `calibrationValue` was never persisted, and calibration was applied immediately instead of after the warm-up the sensor datasheets ask for.

The calibration state now lives in RTC memory as a small warm-up sequence, so a queued calibration survives deep sleep and resumes across wakes. Before applying a recalibration the firmware collects a sensor-specific number of readings over a minimum time and discards the first one, following the datasheet procedure for each sensor. The calibrated value is persisted and included in settings backup/restore, and the web UI can read the real calibration state instead of a static message.

## Changes

- Move calibration state into RTC (`deepSleepData`): warm-up phase, target ppm, readings seen, and start time, so it survives deep sleep.
- Capture a still-pending calibration into RTC as the last step before sleep, after `prepareServicesForDeepSleep()` has stopped WiFi/BLE/MQTT, so a command set by an async radio task can't be lost between the capture and `esp_deep_sleep_start()`.
- Add a per-sensor warm-up requirement (readings + minimum seconds, first reading discarded) and apply the recalibration only once it is met. Progress is logged.
- Persist `calibrationValue` to NVS (`calValue`) on apply and in `putPreferences()`, load it in `initPreferences()`, and add it to JSON export/import.
- Per-sensor low-power handling: SCD4x and SCD30 calibrate across wakes (they stay powered); CM1106 pauses deep sleep for the duration of the calibration and resumes it automatically when done; MH-Z19/S8 stay high-performance-only as today.
- Apply ambient pressure compensation for SCD30/SCD4x (was a stub) and carry a pending value across deep sleep like calibration.
- Add a `/getCalibrationStatus` endpoint and extend `/status` with sensor-aware calibration fields (target, warm-up progress, whether deep sleep is paused). Switched the status JSON to ArduinoJson v7's `JsonDocument` so added fields aren't silently truncated.

## Notes

- The `autoSelfCalibration` menu toggle still does not call the sensor yet. That call needs `setAutoSelfCalibration()` in the sensor library, which I've prepared in a separate `canairio_sensorlib` PR (`lowPowerMode`). The firmware call is staged but commented in `initSensors()`; once the lib change is in I'll move it after sensor detection (it currently sits before `sensors.init()`, so it would be a no-op there) and enable it. This is the one remaining acceptance-criteria item from #250.
- While implementing this I found that the issue's assumption that an SCD4x loses its FRC every wake does not hold for this firmware: `SensirionI2CScd4x::begin()` sends no command, `toDeepSleep()` keeps the SCD41 in single-shot idle (no `powerDown()`), and nothing calls `reinit()` on the wake path, so the correction is retained. The per-sensor status flags and the comments reflect that; details are in the commit messages if useful.
- The commits are split by step (persistence, the deep-sleep race, the warm-up sequence, CM1106, ambient pressure) so they can be reviewed individually.

## Testing

I verified by build; I have not done the on-device runtime/PPK2 testing yet, since I don't currently have all the sensors on hand:

- `pio run -e esp32dev`
- `pio run -e ttgo-t5-EINKBOARDDEPG0213BN`

The flag/sequence logic can be exercised with the `DEMO` sensor (warm-up of one reading) without hardware.


