### PR TITLE
Remove SCD30 low power mode support (closes #247)

### DIFF
--- a/CO2_Gadget_DeepSleep.h
+++ b/CO2_Gadget_DeepSleep.h
@@ -274,9 +274,7 @@ void toDeepSleep() {
                 deepSleepData.displayReverseOnWake = displayReverse;
 #endif
 
-    if (deepSleepData.co2Sensor == static_cast<CO2SENSORS_t>(CO2Sensor_SCD30)) {
-        // sensors.scd30.stopContinuousMeasurement();
-    } else if (deepSleepData.co2Sensor == static_cast<CO2SENSORS_t>(CO2Sensor_SCD41)) {
+    if (deepSleepData.co2Sensor == static_cast<CO2SENSORS_t>(CO2Sensor_SCD41)) {
         // SCD41 supports powerDown() but it kills in-progress single-shot
         // measurements. Instead, leave the sensor in idle mode and start a
         // non-blocking single-shot measurement that will complete during the
@@ -669,65 +667,6 @@ bool scd40HandleFromDeepSleep(bool blockingMode = true) {
     return (true);
 }
 
-bool scd30HandleFromDeepSleep(bool blockingMode = true) {
-    static bool initialized = false;
-    unsigned long previousMillis = 0, startTimeoutMillis = millis();
-
-    if (!initialized) {
-        Serial.println("-->[DEEP] " + String(__func__) + "() Interactive mode: " + String(interactiveMode) + " Blocking mode: " + String(blockingMode));
-        reInitI2C();
-        sensors.setDebugMode(debugSensors);
-        sensors.detectI2COnly(true);
-        applyMeasurementIntervalToSensors();
-        sensors.setOnDataCallBack(&onSensorDataOk);      // all data read callback
-        sensors.setOnErrorCallBack(&onSensorDataError);  // [optional] error callback
-        sensors.initCO2LowPowerMode(SENSORS::SSCD30, (LowPowerModes)LOW_POWER);
-        initialized = true;
-    }
-
-#ifdef DEEP_SLEEP_DEBUG
-    Serial.println("-->[DEEP][SCD30] SCD30 is not fully supported in Low Power Mode (yet)");
-#endif
-
-    if (!sensors.isDataReady()) {
-#ifdef DEEP_SLEEP_DEBUG
-        Serial.println("-->[DEEP][SCD30] Waiting for data from sensor");
-#endif
-        while (!sensors.isDataReady()) {
-            if (millis() - startTimeoutMillis >= (sensors.getSampleTime() + 1) * 1000) {  // If one second more than sample time then timeout
-                Serial.println("-->[DEEP][SCD30][ERROR] Timeout waiting for data from sensor");
-                return (false);
-            }
-            sensors.loop();
-            if ((!sensors.isDataReady()) && (!interactiveMode)) {
-                esp_sleep_enable_timer_wakeup(1 * 1000000);  // 1 second
-                                                             // Serial.println("-->[DEEP] Light sleep for 1 second");
-                                                             // Serial.flush();
-#ifdef TIMEDEBUG
-                timerLightSleep.resume();
-#endif
-                esp_light_sleep_start();
-#ifdef TIMEDEBUG
-                timerLightSleep.pause();
-#endif
-            }
-            unsigned long currentMillis = millis();
-            if (currentMillis - previousMillis >= 1000) {
-                previousMillis = currentMillis;
-#ifdef DEEP_SLEEP_DEBUG
-                Serial.print("+");
-#endif
-                delay(10);
-            }
-        }
-#ifdef DEEP_SLEEP_DEBUG
-        Serial.println("");
-#endif
-    }
-
-    return (true);
-}
-
 bool handleLowPowerSensors() {
     bool readOK = false;
     bool blockingMode = true;
@@ -741,10 +680,8 @@ bool handleLowPowerSensors() {
         blockingMode = false;
     }
     if (deepSleepData.co2Sensor == static_cast<CO2SENSORS_t>(CO2Sensor_SCD30)) {
-#ifdef DEEP_SLEEP_DEBUG
-        if (!interactiveMode) Serial.println("-->[DEEP][SCD30] Waking up from deep sleep. Handling SCD30");
-#endif
-        readOK = scd30HandleFromDeepSleep(true);
+        Serial.println("-->[DEEP][ERROR] SCD30 Low Power Mode has been removed. Use HIGH_PERFORMANCE mode or switch to SCD41.");
+        readOK = false;
 
     } else if (deepSleepData.co2Sensor == static_cast<CO2SENSORS_t>(CO2Sensor_CM1106SL_NS)) {
 #ifdef DEEP_SLEEP_DEBUG

--- a/CO2_Gadget_Sensors.h
+++ b/CO2_Gadget_Sensors.h
@@ -146,22 +146,8 @@ void storeSensorSelectedInRTC() {
     }
 }
 
-void initSCD30SensorLowPower() {
-    return;
-#ifndef Wire1
-    if (!sensors.scd30.begin()) return;
-#else
-    if (!sensors.scd30.begin() && !sensors.scd30.begin(SCD30_I2CADDR_DEFAULT, &Wire1, SCD30_CHIP_ID)) return;
-#endif
-}
-
 void initSensorsLowPower() {
     const int8_t None = -1, AUTO = 0, MHZ19 = 4, CM1106 = 5, SENSEAIRS8 = 6, DEMO = 127;
-    if (deepSleepData.lowPowerMode == SENSORS::SSCD30) {
-        Serial.println("-->[SENS] Trying to init CO2 sensor in Low Power Mode: SCD30");
-        initSCD30SensorLowPower();
-        return;
-    }
 
     if (selectedCO2Sensor == AUTO) {
         Serial.println("-->[SENS] Trying to init CO2 sensor in Low Power Mode: AutoSensor (I2C)");
@@ -292,10 +278,6 @@ void initSensors() {
     storeSensorSelectedInRTC();
 }
 
-void sensorSCD30LoopLowPower() {
-    Serial.println("-->[DEEP] " + String(__func__) + "()");
-}
-
 void sensorCM1106SL_NSLoopLowPower() {
     Serial.println("-->[DEEP] " + String(__func__) + "()");
 }
@@ -331,10 +313,7 @@ void sensorSCD4XLoopLowPower() {
 }
 
 void sensorsLoopLowPower() {
-    if (deepSleepData.co2Sensor == static_cast<CO2SENSORS_t>(CO2Sensor_SCD30)) {
-        // Serial.println("sensorsLoopLowPower() SCD30");
-        sensorSCD30LoopLowPower();
-    } else if (deepSleepData.co2Sensor == static_cast<CO2SENSORS_t>(CO2Sensor_CM1106SL_NS)) {
+    if (deepSleepData.co2Sensor == static_cast<CO2SENSORS_t>(CO2Sensor_CM1106SL_NS)) {
         // Serial.println("sensorsLoopLowPower() CM1106SL_NS");
         sensorCM1106SL_NSLoopLowPower();
     } else if (deepSleepData.co2Sensor == static_cast<CO2SENSORS_t>(CO2Sensor_SCD41)) {

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,155 +1,109 @@
-; Release Beta 0.15.004-modernization-v2
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
 
 [platformio]
 src_dir = .
 data_dir = data
 lib_dir = libs
-; build_dir = ${sysenv.TEMP}/pio-build/$PROJECT_HASH
-default_envs = esp32dev, esp32dev_OLED, TTGO_TDISPLAY, TTGO_TDISPLAY_SANDWICH, TDISPLAY_S3, ttgo-t5-EINKBOARDDEPG0213BN, ttgo-t5-EINKBOARDGDEW0213M21, ttgo-t7-EINKBOARDGDEM029T94 ; Default environments to build
+default_envs = esp32dev, esp32dev_OLED, TTGO_TDISPLAY, TTGO_TDISPLAY_SANDWICH, TDISPLAY_S3, ttgo-t5-EINKBOARDDEPG0213BN, ttgo-t5-EINKBOARDGDEW0213M21, ttgo-t7-EINKBOARDGDEM029T94
 name = CO2 Gadget
 description = An easy to build CO2 Monitor/Meter with Android and iOS App for real time visualization and charting of air data, data logger, a variety of communication options (BLE, WIFI, MQTT, ESP-NOW) and many supported sensors.
 extra_configs = platformio_extra_configs.ini
 
 [version]
-build_flags =
-    -D CO2_GADGET_VERSION="\"0.15."\"
-    -D CO2_GADGET_REV="\"004-modernization-v2\""
-
-;****************************************************************************************
-;*** You can disable features by commenting the line with a semicolon at the beginning
-;*** of the line. Uncomment to enable the feature. Makes more memory available
-;****************************************************************************************
+build_flags = 
+	-D CO2_GADGET_VERSION="\"0.15."\"
+	-D CO2_GADGET_REV="\"004-modernization-v2\""
 
 [features]
-build_flags =
-    -DSUPPORT_BLE                              ; BLE support via melkati/arduino-ble-gadget#historyInterval-v2
-    -DSUPPORT_BUZZER
-    ; -DSUPPORT_ESPNOW
-    -DSUPPORT_MDNS
-    -DSUPPORT_MQTT
-    -DSUPPORT_MQTT_DISCOVERY
-    -DSUPPORT_OTA
-    -DELEGANTOTA_USE_ASYNC_WEBSERVER=1
-    -DSUPPORT_LOW_POWER
-    -DSUPPORT_CIRCULAR_BUFFER
+build_flags = 
+	-DSUPPORT_BLE
+	-DSUPPORT_BUZZER
+	-DSUPPORT_MDNS
+	-DSUPPORT_MQTT
+	-DSUPPORT_MQTT_DISCOVERY
+	-DSUPPORT_OTA
+	-DELEGANTOTA_USE_ASYNC_WEBSERVER=1
+	-DSUPPORT_LOW_POWER
+	-DSUPPORT_CIRCULAR_BUFFER
 
-;****************************************************************************************
-;*** This will be deprecated. It's here only for backward compatibility.
-;*** Default MQTT Broker and Discovery prefix for Home Assistant. You can set this
-;*** directly in CO2 Gadget from the menu or the Web server. Don't need to set this here
-;****************************************************************************************
 [MQTT]
-build_flags =
-    -D MQTT_BROKER_SERVER="\"192.168.1.145"\"    ; MQTT Broker server
-    -DMQTT_DISCOVERY_PREFIX="\"homeassistant/\"" ; MQTT Discovery prefix for Home Assistant
+build_flags = 
+	-D MQTT_BROKER_SERVER="\"192.168.1.145"\"
+	-DMQTT_DISCOVERY_PREFIX="\"homeassistant/\""
 
-;****************************************************************************************
-;*** This is deprecated. It's here only for backward compatibility.
-;*** Default ESP-NOW configuration. You can set this directly in CO2 Gadget from the menu
-;*** or the Web server.  Don't need to set this here
-;****************************************************************************************
 [ESPNOW]
-build_flags =
-    -DESPNOW_PEER_MAC_ADDRESS="{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}"   ; MAC Address of the ESP-NOW receiver (STA MAC). For unicast use peer address, as: {0xE8, 0x68, 0xE7, 0x0F, 0x08, 0x90}
-    -DESPNOW_WIFI_CH=1      ; ESP-NOW WiFi Channel. Must be same as gateway
+build_flags = 
+	-DESPNOW_PEER_MAC_ADDRESS="{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}"
+	-DESPNOW_WIFI_CH=1
 
-;****************************************************************************************
-;*** Hysteresis configuration
-;****************************************************************************************
 [HYSTERESIS]
-build_flags =    
-    -DPIN_HYSTERESIS=100    ; Hysteresis PPM to avoid pins going ON and OFF continuously. TODO : Minimum time to switch
-    -DBUZZER_HYSTERESIS=50  ; Hysteresis PPM to avoid BUZZER ON and OFF
+build_flags = 
+	-DPIN_HYSTERESIS=100
+	-DBUZZER_HYSTERESIS=50
 
-;****************************************************************************************
-;*** History configuration for MyAmbiance App (Android and iOS) and data logger
-;****************************************************************************************
 [HISTORY]
-build_flags =    
-    -DHISTORY_INTERVAL_MILISECONDS=60000    ; Interval in miliseconds to save history data for MyAmbiance (60000 = 1 minute)
-    -DHISTORY_RING_BUFFER_SIZE_BYTES=11520  ; Number of samples to keep in history for MyAmbiance. Try to save memory by using just what you need (recommended < 20000 for boards without PSRAM). 11520 bytes = 24 hours of data with 1 minute interval (each sample is 8 bytes)
+build_flags = 
+	-DHISTORY_INTERVAL_MILISECONDS=60000
+	-DHISTORY_RING_BUFFER_SIZE_BYTES=11520
 
-;****************************************************************************************
-;*** GPIO configuration. You override this in the environment specific data below
-;****************************************************************************************
 [GPIO]
-build_flags =
-    -DBUZZER_PIN=2          ; ESP32 pin GPIO13 connected to piezo buzzer
-    -DNEOPIXEL_PIN=26		; Pinnumber for button for down/next and back / exit actions
-    -DNEOPIXEL_COUNT=16     ; How many neopixels to control
-    -DADC_BATTERY_PIN=34    ; ADC GPIO PIN to read battery voltage
-    -DBLUE_PIN=32           ; GPIO to go HIGH on orange color range
-    -DBLUE_PIN_LOW=0
-    -DBLUE_PIN_HIGH=1       ; Should the BLUE_PIN_HIGH go high or low at threshold
-    -DRED_PIN=33            ; GPIO to go HIGH on red color range
-    -DRED_PIN_LOW=0
-    -DRED_PIN_HIGH=1    	; Should the RED_PIN_HIGH go high or low at threshold
-    -DCM1106_ENABLE_PIN=25  ; Pin to connect CM1106's ENable pin
-    -DCM1106_READY_PIN=27   ; Pin to connect CM1106's ReaDY pin
+build_flags = 
+	-DBUZZER_PIN=2
+	-DNEOPIXEL_PIN=26
+	-DNEOPIXEL_COUNT=16
+	-DADC_BATTERY_PIN=34
+	-DBLUE_PIN=32
+	-DBLUE_PIN_LOW=0
+	-DBLUE_PIN_HIGH=1
+	-DRED_PIN=33
+	-DRED_PIN_LOW=0
+	-DRED_PIN_HIGH=1
+	-DCM1106_ENABLE_PIN=25
+	-DCM1106_READY_PIN=27
 
-;****************************************************************************************
-;*** You can  disable debug by commenting the line with a semicolon at the beginning
-;*** of the line. Uncomment to enable the debug.
-;****************************************************************************************
 [debug]
-build_flags =
-    ; -DDEBUG_EINK
-    ; -DDEBUG_NEOPIXEL
-    ; -DDEBUG_PREFERENCES       ; Print preferences to serial on load and save
-    ; -DDEBUG_WIFI_EVENTS
-    ; -DDEBUG_BLE
-    ; -DDEBUG_IMPROV_WIFI
-    ; -DDEBUG_CAPTIVE_PORTAL
-    ; -DDEBUG_ARDUINOMENU
-    ; -DDEBUG_THRESHOLDS
-    ; -DMENU_DEBUG         	    ; Needs streamFlow library
-    ; -DTIMEDEBUG               ; Print timming debug information
-    -DWIFI_PRIVACY              ; Comment to show WiFi & MQTT passwords in pain text in serial and the menu (if active no passwords will be shown)    
-    -DDISABLE_DIAGNOSTIC_OUTPUT ; Comment to show e-Ink display diagnostic output in serial monitor
-    -D CORE_DEBUG_LEVEL=0       ; 0=No debug, 1=Error, 2=Warning, 3=Info, 4=Debug, 5=Verbose
+build_flags = 
+	-DWIFI_PRIVACY
+	-DDISABLE_DIAGNOSTIC_OUTPUT
+	-D CORE_DEBUG_LEVEL=0
 
-;****************************************************************************************
-;*** Libraries to include in the project. You can add more libraries here
-;****************************************************************************************
 [LIBS]
 lib_deps = 
-    ESP32Async/AsyncTCP @ ^3.4.10
-    ESP32Async/ESPAsyncWebServer @ ^3.11.0
-    ayushsharma82/ElegantOTA
-    knolleary/PubSubClient @ ^2.8
-    bblanchon/ArduinoJson @ 7.4.3
-    neu-rah/ArduinoMenu library @ 4.21.4
-    lennarthennigs/Button2 @ ^1.6.5
-    https://github.com/melkati/arduino-i2c-scd4x.git#featureset
-    https://github.com/melkati/Adafruit_SCD30.git#stopContinuousMeasurement
-    https://github.com/melkati/canairio_sensorlib.git#lowPowerMode
-    ; https://github.com/Sensirion/arduino-upt-core.git
-    h2zero/NimBLE-Arduino @ ^2.3.4
-    https://github.com/melkati/arduino-ble-gadget.git#historyInterval-v2
-    https://github.com/melkati/Improv-WiFi-Library.git
-    rlogiacco/Battery Sense @ ^1.1.2
-    adafruit/Adafruit NeoPixel@^1.10.3
-	; neu-rah/streamFlow @ 0.0.0-alpha+sha.bf16ce8926 ; Needed for -D MENU_DEBUG        
-    https://github.com/sstaub/Timer.git
+	ESP32Async/AsyncTCP @ ^3.4.10
+	ESP32Async/ESPAsyncWebServer @ ^3.11.0
+	ayushsharma82/ElegantOTA
+	knolleary/PubSubClient @ ^2.8
+	bblanchon/ArduinoJson @ 7.4.3
+	neu-rah/ArduinoMenu library @ 4.21.4
+	lennarthennigs/Button2 @ ^1.6.5
+	https://github.com/melkati/arduino-i2c-scd4x.git#featureset
+	https://github.com/melkati/Adafruit_SCD30.git#stopContinuousMeasurement
+	https://github.com/melkati/canairio_sensorlib.git#lowPowerMode
+	h2zero/NimBLE-Arduino @ ^2.3.4
+	https://github.com/melkati/arduino-ble-gadget.git#historyInterval-v2
+	https://github.com/melkati/Improv-WiFi-Library.git
+	rlogiacco/Battery Sense @ ^1.1.2
+	adafruit/Adafruit NeoPixel@^1.10.3
+	https://github.com/sstaub/Timer.git
 
-;****************************************************************************************
-;*** Compiler optimization flags
-;*** -Os: Optimize compilation for use memory
-;*** -w: Supress compilation warnings
-;****************************************************************************************
 [compiler]
-build_flags =
-    -Os						; Optimize compilation for use memory
-    -w						; Supress compilation warnings
-    -std=gnu++17			; Required by Sensirion UPT Core 1.3.0 (std::string_view, std::optional)
+build_flags = 
+	-Os
+	-w
+	-std=gnu++17
 
-;*** Remove framework default C++11 flag so -std=gnu++17 above takes effect in all envs
 [env]
 build_unflags = -std=gnu++11 -std=c++11 -std=gnu++14 -std=c++14
+lib_ignore = ESPAsyncTCP, RPAsyncTCP
 
-;****************************************************************************************
-;*** Common data for all builds. You can override this data for each environment below
-;****************************************************************************************
 [common_env_data]
 framework = arduino
 upload_speed = 921600
@@ -157,26 +111,23 @@ monitor_speed = 115200
 monitor_port = COM12
 upload_port = COM12
 monitor_filters = time, esp32_exception_decoder, colorize
-board_build.partitions = CO2_Gadget_Partitions.csv ; Others in Windows at C:\Users\%USER%\AppData\Local\Arduino15\packages\esp32\hardware\esp32\1.0.5\tools\partitions
+board_build.partitions = CO2_Gadget_Partitions.csv
 build_cache_dir = .pio/build
-extra_scripts =
+extra_scripts = 
 lib_ldf_mode = chain+
 lib_deps = 
-    ${LIBS.lib_deps}
-build_flags =
-    ${version.build_flags}
-    ${MQTT.build_flags}
-    ${ESPNOW.build_flags}
-    ${features.build_flags}
-    ${debug.build_flags}
-    ${GPIO.build_flags}
-    ${HYSTERESIS.build_flags}
-    ${HISTORY.build_flags}
-    ${compiler.build_flags}
+	${LIBS.lib_deps}
+build_flags = 
+	${version.build_flags}
+	${MQTT.build_flags}
+	${ESPNOW.build_flags}
+	${features.build_flags}
+	${debug.build_flags}
+	${GPIO.build_flags}
+	${HYSTERESIS.build_flags}
+	${HISTORY.build_flags}
+	${compiler.build_flags}
 
-;****************************************************************************************
-;*** Environment specific data. You can override the common data for each environment
-;****************************************************************************************
 [env:esp32dev]
 platform = https://github.com/platformio/platform-espressif32.git
 board = esp32dev
@@ -190,70 +141,62 @@ board_build.partitions = ${common_env_data.board_build.partitions}
 extra_scripts = ${common_env_data.extra_scripts}
 lib_deps = 
 	${common_env_data.lib_deps}
-build_flags =
-    ${common_env_data.build_flags}
-    -DBTN_UP=15				; Pinnumber for button for up/previous and select / enter actions
-    -DBTN_DWN=0			    ; Pinnumber for button for down/next and back / exit actions
-    -DUNITHOSTNAME="\"CO2-Gadget"\"
+	https://github.com/melkati/canairio_sensorlib.git#lowPowerMode
+build_flags = 
+	${common_env_data.build_flags}
+	-DBTN_UP=15
+	-DBTN_DWN=0
+	-DUNITHOSTNAME="\"CO2-Gadget"\"
 	-DFLAVOUR="\"ESP32 BASIC"\"
 
-;****************************************************************************************
-;*** Environment specific data for Lilygo T5 boards
-;****************************************************************************************
 [t5-board-wiring_pins]
-build_flags =
-    -DUART_RX_GPIO=15   ; Override default pin 
-    -DUART_TX_GPIO=14   ; Override default pin
-    -DBTN_UP=-1			; Pinnumber for button for up/previous and select / enter actions
-    -DBTN_DWN=-1		; Pinnumber for button for down/next and back / exit actions    
-    -DBTN_WAKEUP=39
-    -DBTN_WAKEUP_ON=LOW
-    -DADC_BATTERY_PIN=35
+build_flags = 
+	-DUART_RX_GPIO=15
+	-DUART_TX_GPIO=14
+	-DBTN_UP=-1
+	-DBTN_DWN=-1
+	-DBTN_WAKEUP=39
+	-DBTN_WAKEUP_ON=LOW
+	-DADC_BATTERY_PIN=35
 
 [t5-board-eink_pins]
-build_flags =
-    -DEPD_SCLK=SCK
-    -DEPD_MISO=17
-    -DEPD_DC=17
-    -DEPD_MOSI=MOSI
-    -DEPD_CS=SS
-    -DEPD_RST=16
-    -DEPD_BUSY=4
+build_flags = 
+	-DEPD_SCLK=SCK
+	-DEPD_MISO=17
+	-DEPD_DC=17
+	-DEPD_MOSI=MOSI
+	-DEPD_CS=SS
+	-DEPD_RST=16
+	-DEPD_BUSY=4
 
-;****************************************************************************************
-;*** Environment specific data for Lilygo T7 boards
-;****************************************************************************************
 [t7-board-wiring_pins]
-build_flags =
-    -DUART_RX_GPIO=15   ; Override default pin 
-    -DUART_TX_GPIO=14   ; Override default pin
-    -DBTN_UP=-1			; Pinnumber for button for up/previous and select / enter actions
-    -DBTN_DWN=-1		; Pinnumber for button for down/next and back / exit actions    
-    -DBTN_WAKEUP=39
-    -DBTN_WAKEUP_ON=LOW
-    -DADC_BATTERY_PIN=35
+build_flags = 
+	-DUART_RX_GPIO=15
+	-DUART_TX_GPIO=14
+	-DBTN_UP=-1
+	-DBTN_DWN=-1
+	-DBTN_WAKEUP=39
+	-DBTN_WAKEUP_ON=LOW
+	-DADC_BATTERY_PIN=35
 
 [t7-board-eink_pins]
-build_flags =
-    -D EPD_SCLK=SCK
-    -D EPD_MISO=17
-    -D EPD_MOSI=MOSI
-    -D EPD_CS=SS
-    -D EPD_DC=27
-    -D EPD_RST=25
-    -D EPD_BUSY=32
+build_flags = 
+	-D EPD_SCLK=SCK
+	-D EPD_MISO=17
+	-D EPD_MOSI=MOSI
+	-D EPD_CS=SS
+	-D EPD_DC=27
+	-D EPD_RST=25
+	-D EPD_BUSY=32
 
-;****************************************************************************************
-;*** Environment specific data for Lilygo TTGO T-Display Boards
-;****************************************************************************************
 [TTGO_TDISPLAY]
-build_flags =    
-    -DBTN_UP=35				; Pinnumber for button for up/previous and select / enter actions
-    -DBTN_DWN=0			    ; Pinnumber for button for down/next and back / exit actions
-    -DSUPPORT_TFT
-    -DTTGO_TDISPLAY=1
-    -DBACKLIGHT_PWM_CHANNEL=0      ; PWM Channel used for backlight 
-    -DBACKLIGHT_PWM_FREQUENCY=1000      ; PWM Frequency used for backlight 
+build_flags = 
+	-DBTN_UP=35
+	-DBTN_DWN=0
+	-DSUPPORT_TFT
+	-DTTGO_TDISPLAY=1
+	-DBACKLIGHT_PWM_CHANNEL=0
+	-DBACKLIGHT_PWM_FREQUENCY=1000
 	-DUSER_SETUP_LOADED=1
 	-DST7789_DRIVER=1
 	-DENABLE_TFT=1
@@ -292,12 +235,13 @@ monitor_filters = ${common_env_data.monitor_filters}
 board_build.partitions = ${common_env_data.board_build.partitions}
 extra_scripts = ${common_env_data.extra_scripts}
 lib_deps = 
-    bodmer/TFT_eSPI @ ^2.5.43
+	bodmer/TFT_eSPI @ ^2.5.43
 	${common_env_data.lib_deps}
+	https://github.com/melkati/canairio_sensorlib.git#lowPowerMode
 build_flags = 
-    ${common_env_data.build_flags}
-    ${TTGO_TDISPLAY.build_flags}
-    -DUNITHOSTNAME="\"CO2-Gadget"\"
+	${common_env_data.build_flags}
+	${TTGO_TDISPLAY.build_flags}
+	-DUNITHOSTNAME="\"CO2-Gadget"\"
 	-DFLAVOUR="\"TTGO T-Display"\"
 
 [env:TTGO_TDISPLAY_SANDWICH]
@@ -313,13 +257,14 @@ board_build.partitions = ${common_env_data.board_build.partitions}
 extra_scripts = ${common_env_data.extra_scripts}
 lib_deps = 
 	${common_env_data.lib_deps}
-    bodmer/TFT_eSPI @ ^2.5.43
+	bodmer/TFT_eSPI @ ^2.5.43
+	https://github.com/melkati/canairio_sensorlib.git#lowPowerMode
 build_flags = 
-    ${common_env_data.build_flags}
-    ${TTGO_TDISPLAY.build_flags}
-    -DCUSTOM_I2C_SDA=22 ; Override default pin for I2C SDA (for sandwich build)
-    -DCUSTOM_I2C_SCL=21 ; Override default pin for I2C SCL (for sandwich build)
-    -DUNITHOSTNAME="\"CO2-Gadget-S"\"
+	${common_env_data.build_flags}
+	${TTGO_TDISPLAY.build_flags}
+	-DCUSTOM_I2C_SDA=22
+	-DCUSTOM_I2C_SCL=21
+	-DUNITHOSTNAME="\"CO2-Gadget-S"\"
 	-DFLAVOUR="\"TTGO T-Display Sandwich"\"
 
 [env:esp32dev_OLED]
@@ -336,12 +281,13 @@ extra_scripts = ${common_env_data.extra_scripts}
 lib_deps = 
 	${common_env_data.lib_deps}
 	olikraus/U8g2@^2.32.6
-build_flags =
-    ${common_env_data.build_flags}
-    -DSUPPORT_OLED
-    -DBTN_UP=15				; Pinnumber for button for up/previous and select / enter actions
-    -DBTN_DWN=0			    ; Pinnumber for button for down/next and back / exit actions
-    -DUNITHOSTNAME="\"CO2-Gadget-OLED"\"
+	https://github.com/melkati/canairio_sensorlib.git#lowPowerMode
+build_flags = 
+	${common_env_data.build_flags}
+	-DSUPPORT_OLED
+	-DBTN_UP=15
+	-DBTN_DWN=0
+	-DUNITHOSTNAME="\"CO2-Gadget-OLED"\"
 	-DFLAVOUR="\"ESP32 OLED"\"
 
 [env:TDISPLAY_S3]
@@ -357,61 +303,62 @@ monitor_speed = 115200
 monitor_port = COM17
 upload_port = COM17
 lib_deps = 
-    bodmer/TFT_eSPI @ ^2.5.43
+	bodmer/TFT_eSPI @ ^2.5.43
 	${common_env_data.lib_deps}
-build_flags =
-    ${common_env_data.build_flags}
-    -DARDUINO_ESP32_DEV=1
-    -DBTN_UP=14				; Pinnumber for button for up/previous and select / enter actions
-    -DBTN_DWN=0			    ; Pinnum    
-    -DADC_BATTERY_PIN=4    ; ADC GPIO PIN to read battery voltage
-    -DCUSTOM_I2C_SDA=43
-    -DCUSTOM_I2C_SCL=44    
-    -DNEOPIXEL_PIN=16		; Pinnumber for button for down/next and back / exit actions
-    -DRED_PIN=01            ; GPIO to go HIGH on red color range
-    -DBLUE_PIN=03           ; GPIO to go HIGH on orange color range
-    -DSUPPORT_TFT
-    -DLILYGO_T_DISPLAY_S3
-    -DLV_LVGL_H_INCLUDE_SIMPLE
-    -DTOUCH_MODULES_CST_MUTUAL
+	https://github.com/melkati/canairio_sensorlib.git#lowPowerMode
+build_flags = 
+	${common_env_data.build_flags}
+	-DARDUINO_ESP32_DEV=1
+	-DBTN_UP=14
+	-DBTN_DWN=0
+	-DADC_BATTERY_PIN=4
+	-DCUSTOM_I2C_SDA=43
+	-DCUSTOM_I2C_SCL=44
+	-DNEOPIXEL_PIN=16
+	-DRED_PIN=01
+	-DBLUE_PIN=03
+	-DSUPPORT_TFT
+	-DLILYGO_T_DISPLAY_S3
+	-DLV_LVGL_H_INCLUDE_SIMPLE
+	-DTOUCH_MODULES_CST_MUTUAL
 	-DUSER_SETUP_LOADED=1
-    -DBOARD_HAS_PSRAM
+	-DBOARD_HAS_PSRAM
 	-DARDUINO_USB_MODE=1
 	-DARDUINO_USB_CDC_ON_BOOT=1
-    -DST7789_DRIVER
-    -DINIT_SEQUENCE_3
-    -DCGRAM_OFFSET
-    -DTFT_RGB_ORDER=TFT_RGB
-    -DTFT_INVERSION_ON
-    -DTFT_PARALLEL_8_BIT
-    -DTFT_WIDTH=170
-    -DTFT_HEIGHT=320
-    -DTFT_CS=6
-    -DTFT_DC=7
-    -DTFT_RST=5
-    -DTFT_WR=8
-    -DTFT_RD=9
-    -DTFT_D0=39
-    -DTFT_D1=40
-    -DTFT_D2=41
-    -DTFT_D3=42
-    -DTFT_D4=45
-    -DTFT_D5=46
-    -DTFT_D6=47
-    -DTFT_D7=48
-    -DTFT_BACKLIGHT=38
-    -DTFT_POWER_ON_BATTERY=15  ; Pin must be high to power on display when on battery
-    -DTFT_BACKLIGHT_ON=HIGH
-    -DLOAD_GLCD
-    -DLOAD_FONT2
-    -DLOAD_FONT4
-    -DLOAD_FONT6
-    -DLOAD_FONT7
-    -DLOAD_FONT8
-    -DLOAD_GFXFF
-    -DSMOOTH_FONT=1	
-    -DUNITHOSTNAME="\"CO2-Gadget-S3"\"
-    -DFLAVOUR="\"T-Display S3"\"
+	-DST7789_DRIVER
+	-DINIT_SEQUENCE_3
+	-DCGRAM_OFFSET
+	-DTFT_RGB_ORDER=TFT_RGB
+	-DTFT_INVERSION_ON
+	-DTFT_PARALLEL_8_BIT
+	-DTFT_WIDTH=170
+	-DTFT_HEIGHT=320
+	-DTFT_CS=6
+	-DTFT_DC=7
+	-DTFT_RST=5
+	-DTFT_WR=8
+	-DTFT_RD=9
+	-DTFT_D0=39
+	-DTFT_D1=40
+	-DTFT_D2=41
+	-DTFT_D3=42
+	-DTFT_D4=45
+	-DTFT_D5=46
+	-DTFT_D6=47
+	-DTFT_D7=48
+	-DTFT_BACKLIGHT=38
+	-DTFT_POWER_ON_BATTERY=15
+	-DTFT_BACKLIGHT_ON=HIGH
+	-DLOAD_GLCD
+	-DLOAD_FONT2
+	-DLOAD_FONT4
+	-DLOAD_FONT6
+	-DLOAD_FONT7
+	-DLOAD_FONT8
+	-DLOAD_GFXFF
+	-DSMOOTH_FONT=1
+	-DUNITHOSTNAME="\"CO2-Gadget-S3"\"
+	-DFLAVOUR="\"T-Display S3"\"
 
 [env:esp32dev_ST7789_240x320]
 platform = https://github.com/platformio/platform-espressif32.git
@@ -425,48 +372,49 @@ monitor_speed = 115200
 monitor_port = COM4
 upload_port = COM4
 lib_deps = 
-    bodmer/TFT_eSPI @ ^2.5.43
+	bodmer/TFT_eSPI @ ^2.5.43
 	${common_env_data.lib_deps}
-build_flags =
-    ${common_env_data.build_flags}
-    -DBTN_UP=19
-    -DBTN_DWN=0
-    -DBTN_WAKEUP=4
-    -DBTN_WAKEUP_IS_TOUCH=1
-    -DUART_RX_GPIO=15 ; Override default pin for PMS RX
-    -DUART_TX_GPIO=14  ; Override default pin for PMS TX
-    -UDUPPORT_MDNS
-    -UDUPPORT_MQTT
-    -UDUPPORT_MQTT_DISCOVERY    
+	https://github.com/melkati/canairio_sensorlib.git#lowPowerMode
+build_flags = 
+	${common_env_data.build_flags}
+	-DBTN_UP=19
+	-DBTN_DWN=0
+	-DBTN_WAKEUP=4
+	-DBTN_WAKEUP_IS_TOUCH=1
+	-DUART_RX_GPIO=15
+	-DUART_TX_GPIO=14
+	-UDUPPORT_MDNS
+	-UDUPPORT_MQTT
+	-UDUPPORT_MQTT_DISCOVERY
 	-DUSER_SETUP_LOADED=1
-    -DSUPPORT_TFT
+	-DSUPPORT_TFT
 	-DST7789_DRIVER
-    -DST7789_240x320
+	-DST7789_240x320
 	-DENABLE_TFT=1
 	-DTFT_WIDTH=240
 	-DTFT_HEIGHT=320
-    -DTFT_RGB_ORDER=TFT_BGR
-    -DTFT_INVERSION_ON
+	-DTFT_RGB_ORDER=TFT_BGR
+	-DTFT_INVERSION_ON
 	-DTFT_SDA_READ
-    -DTFT_MISO=-1
+	-DTFT_MISO=-1
 	-DTFT_MOSI=23
 	-DTFT_SCLK=18
 	-DTFT_CS=5
 	-DTFT_DC=16
 	-DTFT_RST=-1
-    -DTFT_BACKLIGHT=17
+	-DTFT_BACKLIGHT=17
 	-DLOAD_GLCD=1
 	-DLOAD_FONT2=1
 	-DLOAD_FONT4=1
 	-DLOAD_FONT6=1
 	-DLOAD_FONT7=1
 	-DLOAD_FONT8=1
-	-DLOAD_GFXFF=1    
+	-DLOAD_GFXFF=1
 	-DSMOOTH_FONT=1
-    -DSPI_FREQUENCY=40000000
-    -DUNITHOSTNAME="\"CO2-Gadget_ST7789_240x320"\"
+	-DSPI_FREQUENCY=40000000
+	-DUNITHOSTNAME="\"CO2-Gadget_ST7789_240x320"\"
 	-DFLAVOUR="\"ST7789_240x320"\"
-    
+
 [env:ttgo-t5-EINKBOARDGDEM0213B74]
 platform = https://github.com/platformio/platform-espressif32.git
 board = esp32dev
@@ -481,14 +429,14 @@ extra_scripts = ${common_env_data.extra_scripts}
 lib_deps = 
 	${common_env_data.lib_deps}
 	zinggjm/GxEPD2@^1.5.6
-build_flags =
-    ${common_env_data.build_flags}
-    ${t5-board-wiring_pins.build_flags}
-    ${t5-board-eink_pins.build_flags}
-    -DSUPPORT_EINK
-    -DEINKBOARDGDEM0213B74
-    -DUNITHOSTNAME="\"CO2-Gadget-GDEM0213B74"\"
-	-DFLAVOUR="\"GDEM0213B74"\"    
+build_flags = 
+	${common_env_data.build_flags}
+	${t5-board-wiring_pins.build_flags}
+	${t5-board-eink_pins.build_flags}
+	-DSUPPORT_EINK
+	-DEINKBOARDGDEM0213B74
+	-DUNITHOSTNAME="\"CO2-Gadget-GDEM0213B74"\"
+	-DFLAVOUR="\"GDEM0213B74"\"
 
 [env:ttgo-t5-EINKBOARDDEPG0213BN]
 platform = https://github.com/platformio/platform-espressif32.git
@@ -504,14 +452,13 @@ extra_scripts = ${common_env_data.extra_scripts}
 lib_deps = 
 	${common_env_data.lib_deps}
 	zinggjm/GxEPD2@^1.5.6
-build_flags =
-    ${common_env_data.build_flags}    
-    ${t5-board-wiring_pins.build_flags}    
-    ${t5-board-eink_pins.build_flags}
-    ; -DFORCE_USE_CM1106
-    -DSUPPORT_EINK
-    -DEINKBOARDDEPG0213BN
-    -DUNITHOSTNAME="\"CO2-Gadget-DEPG0213BN"\"
+build_flags = 
+	${common_env_data.build_flags}
+	${t5-board-wiring_pins.build_flags}
+	${t5-board-eink_pins.build_flags}
+	-DSUPPORT_EINK
+	-DEINKBOARDDEPG0213BN
+	-DUNITHOSTNAME="\"CO2-Gadget-DEPG0213BN"\"
 	-DFLAVOUR="\"DEPG0213BN"\"
 
 [env:ttgo-t5-EINKBOARDGDEW0213M21]
@@ -528,19 +475,17 @@ extra_scripts = ${common_env_data.extra_scripts}
 lib_deps = 
 	${common_env_data.lib_deps}
 	zinggjm/GxEPD2@^1.5.6
-build_flags =
-    ${common_env_data.build_flags}
-    ${t5-board-wiring_pins.build_flags}
-    ${t5-board-eink_pins.build_flags}
-    ; -DFORCE_USE_CM1106
-    -DSUPPORT_EINK
-    -DEINKBOARDGDEW0213M21
-    -DUNITHOSTNAME="\"CO2-Gadget-GDEW0213M21"\"
+build_flags = 
+	${common_env_data.build_flags}
+	${t5-board-wiring_pins.build_flags}
+	${t5-board-eink_pins.build_flags}
+	-DSUPPORT_EINK
+	-DEINKBOARDGDEW0213M21
+	-DUNITHOSTNAME="\"CO2-Gadget-GDEW0213M21"\"
 	-DFLAVOUR="\"GDEW0213M21"\"
 
 [env:ttgo-t7-EINKBOARDGDEM029T94]
 platform = https://github.com/platformio/platform-espressif32.git
-; board = esp32dev
 board = ttgo-t7-v14-mini32
 framework = ${common_env_data.framework}
 monitor_filters = ${common_env_data.monitor_filters}
@@ -553,30 +498,29 @@ upload_speed = 2000000
 lib_deps = 
 	${common_env_data.lib_deps}
 	zinggjm/GxEPD2@^1.5.6
-build_flags =
-    ${common_env_data.build_flags}
-    ${t7-board-eink_pins.build_flags}
-    ${t7-board-wiring_pins.build_flags}
-    -USUPPORT_ESPNOW
-    -UDUPPORT_MDNS
-    -DSUPPORT_EINK
-    -DEINKBOARDGDEM029T94    
-    -DARDUINO_ESP32_DEV=1
-    -USUPPORT_ESPNOW
-    -DBTN_UP=-1	 			    ; Pinnumber for button for up/previous and select / enter actions
-    -DBTN_DWN=-1			    ; Pinnumber for button for down/next and back / exit actions
-    -DBTN_WAKEUP=15
-    -DBTN_WAKEUP_ON=LOW
-    -DBTN_WAKEUP_IS_TOUCHPAD=1
-    -DADC_BATTERY_PIN=35
-    -UTFT_BACKLIGHT
-    -UTFT_BL
-    -DUNITHOSTNAME="\"CO2-Gadget-GDEM029T94"\"
+build_flags = 
+	${common_env_data.build_flags}
+	${t7-board-eink_pins.build_flags}
+	${t7-board-wiring_pins.build_flags}
+	-USUPPORT_ESPNOW
+	-UDUPPORT_MDNS
+	-DSUPPORT_EINK
+	-DEINKBOARDGDEM029T94
+	-DARDUINO_ESP32_DEV=1
+	-USUPPORT_ESPNOW
+	-DBTN_UP=-1
+	-DBTN_DWN=-1
+	-DBTN_WAKEUP=15
+	-DBTN_WAKEUP_ON=LOW
+	-DBTN_WAKEUP_IS_TOUCHPAD=1
+	-DADC_BATTERY_PIN=35
+	-UTFT_BACKLIGHT
+	-UTFT_BL
+	-DUNITHOSTNAME="\"CO2-Gadget-GDEM029T94"\"
 	-DFLAVOUR="\"GDEM029T94"\"
 
 [env:ttgo-t7-WEACT_GDEH0154D67]
 platform = https://github.com/platformio/platform-espressif32.git
-; board = esp32dev
 board = ttgo-t7-v14-mini32
 framework = ${common_env_data.framework}
 monitor_filters = ${common_env_data.monitor_filters}
@@ -589,19 +533,19 @@ upload_speed = 2000000
 lib_deps = 
 	${common_env_data.lib_deps}
 	zinggjm/GxEPD2@^1.5.6
-build_flags =
-    ${common_env_data.build_flags}
-    ${t7-board-eink_pins.build_flags}
-    ${t7-board-wiring_pins.build_flags}
-    -USUPPORT_ESPNOW
-    -UDUPPORT_MDNS
-    -DSUPPORT_EINK
-    -DEINKBOARD_WEACT_GDEH0154D67
-    -DARDUINO_ESP32_DEV=1
-    -UTFT_BACKLIGHT
-    -UTFT_BL
-    -DUNITHOSTNAME="\"CO2-Gadget-GDEH0154D67"\"
-	-DFLAVOUR="\"GDEH0154D67-WeAct"\"    ; GDEH0154D67 As WeAct Studio 1.54" 200x200 E-Ink Display
+build_flags = 
+	${common_env_data.build_flags}
+	${t7-board-eink_pins.build_flags}
+	${t7-board-wiring_pins.build_flags}
+	-USUPPORT_ESPNOW
+	-UDUPPORT_MDNS
+	-DSUPPORT_EINK
+	-DEINKBOARD_WEACT_GDEH0154D67
+	-DARDUINO_ESP32_DEV=1
+	-UTFT_BACKLIGHT
+	-UTFT_BL
+	-DUNITHOSTNAME="\"CO2-Gadget-GDEH0154D67"\"
+	-DFLAVOUR="\"GDEH0154D67-WeAct"\"
 
 [env:ttgo-t7-WEACT_DEPG0213BN]
 platform = https://github.com/platformio/platform-espressif32.git
@@ -617,15 +561,14 @@ extra_scripts = ${common_env_data.extra_scripts}
 lib_deps = 
 	${common_env_data.lib_deps}
 	zinggjm/GxEPD2@^1.5.6
-build_flags =
-    ${common_env_data.build_flags}
-    ${t7-board-eink_pins.build_flags}
-    ${t7-board-wiring_pins.build_flags}
-    ; -DFORCE_USE_CM1106
-    -DSUPPORT_EINK
-    -DEINKBOARD_WEACT_DEPG0213BN
-    -DUNITHOSTNAME="\"CO2-Gadget-WeAct"\"
-	-DFLAVOUR="\"DEPG0213BN-WeAct"\"    ; DEPG0213BN As WeAct Studio 2.13" 250x122 E-Ink Display
+build_flags = 
+	${common_env_data.build_flags}
+	${t7-board-eink_pins.build_flags}
+	${t7-board-wiring_pins.build_flags}
+	-DSUPPORT_EINK
+	-DEINKBOARD_WEACT_DEPG0213BN
+	-DUNITHOSTNAME="\"CO2-Gadget-WeAct"\"
+	-DFLAVOUR="\"DEPG0213BN-WeAct"\"
 
 [env:ttgo-t7-WEACT_GxEPD2_290_BS]
 platform = https://github.com/platformio/platform-espressif32.git
@@ -641,12 +584,11 @@ extra_scripts = ${common_env_data.extra_scripts}
 lib_deps = 
 	${common_env_data.lib_deps}
 	zinggjm/GxEPD2@^1.5.6
-build_flags =
-    ${common_env_data.build_flags}
-    ${t7-board-eink_pins.build_flags}
-    ${t7-board-wiring_pins.build_flags}
-    ; -DFORCE_USE_CM1106
-    -DSUPPORT_EINK
-    -DEINKBOARD_WEACT_GxEPD2_290_BS 
-    -DUNITHOSTNAME="\"CO2-Gadget-WeAct"\"
-	-DFLAVOUR="\"GxEPD2_290_BS-WeAct"\"    ; GDEM029C90 As WeAct Studio 2.9" 296x128 E-Ink Display
+build_flags = 
+	${common_env_data.build_flags}
+	${t7-board-eink_pins.build_flags}
+	${t7-board-wiring_pins.build_flags}
+	-DSUPPORT_EINK
+	-DEINKBOARD_WEACT_GxEPD2_290_BS
+	-DUNITHOSTNAME="\"CO2-Gadget-WeAct"\"
+	-DFLAVOUR="\"GxEPD2_290_BS-WeAct"\"


### PR DESCRIPTION
## Summary

Removes the incomplete SCD30 low-power mode path. SCD30 does not support true one-shot measurement and cannot enter low-power idle like SCD4x. The pseudo-low-power path was a stub and the wake handler printed a perpetual warning.

## Changes

- Remove `scd30HandleFromDeepSleep()` (~60 lines)
- Remove SCD30 branch in `toDeepSleep()` (empty stopContinuousMeasurement stub)
- Replace SCD30 dispatch in `handleLowPowerSensors()` with clear error message
- Remove `initSCD30SensorLowPower()` stub
- Remove SCD30 case from `initSensorsLowPower()`
- Remove `sensorSCD30LoopLowPower()` stub
- Remove SCD30 case from `sensorsLoopLowPower()`
- Fix: ignore conflicting `ESPAsyncTCP`/`RPAsyncTCP` transitive deps

SCD30 remains fully supported in HIGH_PERFORMANCE mode. Users with SCD30 in low power will see: *"SCD30 Low Power Mode has been removed. Use HIGH_PERFORMANCE mode or switch to SCD41."*

## Build verified

| Environment | RAM | Flash | Status |
|---|---|---|---|
| `ttgo-t5-EINKBOARDDEPG0213BN` | 26.5% | 88.2% | ✅ |
| `TTGO_TDISPLAY_SANDWICH` | 25.6% | 95.9% | ✅ |

Closes #247