### PR TITLE
feat(bthome): BTHome v2 BLE advertising for Home Assistant

### DIFF
--- a/CO2_Gadget_BTHome.h
+++ b/CO2_Gadget_BTHome.h
@@ -33,7 +33,7 @@ uint16_t encodeBTHomeBatteryVoltage(float value) {
     if (value <= 0.0f) {
         return 0;
     }
-    uint32_t millivolts = static_cast<uint32_t>(round(value * 100.0f)) * 10;
+    uint32_t millivolts = static_cast<uint32_t>(round(value * 1000.0f));
     if (millivolts > UINT16_MAX) {
         return UINT16_MAX;
     }

--- a/CO2_Gadget_DeepSleep.h
+++ b/CO2_Gadget_DeepSleep.h
@@ -410,6 +410,8 @@ void toDeepSleep() {
 #endif
     printRTCMemoryEnter();
 
+    esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_ALL);
+
 #ifdef BTN_WAKEUP_IS_TOUCHPAD
     // Setup interrupt on Touch Pad 0 (GPIO15)
     // touchAttachInterrupt(T3, callbackTouch, 40);

--- a/CO2_Gadget_EINK.h
+++ b/CO2_Gadget_EINK.h
@@ -584,20 +584,20 @@ void showTemperature(float temp, int32_t posX, int32_t posY, bool forceRedraw) {
 void showBLEIcon(int32_t posX, int32_t posY, bool forceRedraw) {
     //    display.fillRect(posX, posY, 16+6, 16+6, GxEPD_WHITE);
     //    display.drawRoundRect(posX, posY, 16 + 6, 16 + 6, 2, GxEPD_BLACK);
+    if (!displayShowStatusIcons) return;
     bool bleStatusActive = enableBLE && activeBLE;
 #ifdef SUPPORT_LOW_POWER
     if ((esp_reset_reason() == ESP_RST_DEEPSLEEP) && (esp_sleep_get_wakeup_cause() == ESP_SLEEP_WAKEUP_TIMER) && !interactiveMode) {
         bleStatusActive = deepSleepData.activeBLEOnWake && enableBLE && activeBLE;
     }
 #endif
-    if (bleStatusActive) {
-        display.drawBitmap(posX, posY, iconBluetoothBW, 16, 16, GxEPD_BLACK);
-    } else {
-        return;
-    }
+    if (!bleStatusActive) return;
+
+    display.drawBitmap(posX, posY, iconBluetoothBW, 16, 16, GxEPD_BLACK);
 }
 
 void showBTHomeIcon(int32_t posX, int32_t posY, bool forceRedraw) {
+    if (!displayShowStatusIcons) return;
 #ifdef SUPPORT_BTHOME_BLE
     bool bthomeStatusActive = enableBLE && activeBTHome;
 #ifdef SUPPORT_LOW_POWER
@@ -605,15 +605,14 @@ void showBTHomeIcon(int32_t posX, int32_t posY, bool forceRedraw) {
         bthomeStatusActive = deepSleepData.activeBLEOnWake && enableBLE && activeBTHome;
     }
 #endif
-    if (bthomeStatusActive) {
-        display.drawBitmap(posX, posY, iconBTHome, 16, 16, GxEPD_BLACK);
-    } else {
-        return;
-    }
+    if (!bthomeStatusActive) return;
+
+    display.drawBitmap(posX, posY, iconBTHome, 16, 16, GxEPD_BLACK);
 #endif
 }
 
 void showWiFiIcon(int32_t posX, int32_t posY, bool forceRedraw) {
+    if (!displayShowStatusIcons) return;
     bool wifiStatusActive = activeWIFI;
 #ifdef SUPPORT_LOW_POWER
     if ((esp_reset_reason() == ESP_RST_DEEPSLEEP) && (esp_sleep_get_wakeup_cause() == ESP_SLEEP_WAKEUP_TIMER) && !interactiveMode) {
@@ -654,6 +653,7 @@ void showWiFiIcon(int32_t posX, int32_t posY, bool forceRedraw) {
 }
 
 void showMQTTIcon(int32_t posX, int32_t posY, bool forceRedraw) {
+    if (!displayShowStatusIcons) return;
 #ifdef SUPPORT_MQTT
     bool mqttStatusActive = activeMQTT;
 #ifdef SUPPORT_LOW_POWER
@@ -661,35 +661,32 @@ void showMQTTIcon(int32_t posX, int32_t posY, bool forceRedraw) {
         mqttStatusActive = deepSleepData.sendMQTTOnWake;
     }
 #endif
-    if (mqttStatusActive) {
-        if (troubledMQTT) {
-            display.drawBitmap(posX, posY, iconMQTT, 16, 16, GxEPD_BLACK);
-        } else {
-            display.drawInvertedBitmap(posX, posY, iconMQTT, 16, 16, GxEPD_BLACK);
-        }
+    if (!mqttStatusActive) return;
+
+    if (troubledMQTT) {
+        display.drawBitmap(posX, posY, iconMQTT, 16, 16, GxEPD_BLACK);
+    } else {
+        display.drawInvertedBitmap(posX, posY, iconMQTT, 16, 16, GxEPD_BLACK);
     }
 #endif
 }
 
 void showEspNowIcon(int32_t posX, int32_t posY, bool forceRedraw) {
+    if (!displayShowStatusIcons) return;
 #ifdef SUPPORT_ESPNOW
-    display.fillRect(posX, posY, 16, 16, GxEPD_WHITE);
-    if (activeESPNOW) {
-        if (troubledESPNOW) {
-            // display.drawRoundRect(posX, posY, 16 + 6, 16 + 6, 2, GxEPD_BLACK);
-            display.drawBitmap(posX, posY, iconEspNow, 16, 16, GxEPD_BLACK);
-            return;
-        } else {
-            display.drawInvertedBitmap(posX, posY, iconEspNow, 16, 16, GxEPD_BLACK);
-        }
-        // // display.drawRoundRect(posX, posY, 16 + 6, 16 + 6, 2, GxEPD_BLACK);
-        // if (!activeESPNOW) {
-        //     // when is disabled I think is better show nothing but for debug purposes show it in inverse mode
-        //     display.drawBitmap(posX, posY, iconEspNow, 16, 16, GxEPD_BLACK);
-        // } else {
-        //     display.drawInvertedBitmap(posX, posY, iconEspNow, 16, 16, GxEPD_BLACK);
-        // }
+    bool espNowStatusActive = activeESPNOW;
+#ifdef SUPPORT_LOW_POWER
+    if ((esp_reset_reason() == ESP_RST_DEEPSLEEP) && (esp_sleep_get_wakeup_cause() == ESP_SLEEP_WAKEUP_TIMER) && !interactiveMode) {
+        espNowStatusActive = deepSleepData.sendESPNowOnWake;
     }
+#endif
+    if (!espNowStatusActive) return;
+
+    if (troubledESPNOW) {
+        display.drawBitmap(posX, posY, iconEspNow, 16, 16, GxEPD_BLACK);
+        return;
+    }
+    display.drawInvertedBitmap(posX, posY, iconEspNow, 16, 16, GxEPD_BLACK);
 #endif
 }
 

--- a/CO2_Gadget_TFT.h
+++ b/CO2_Gadget_TFT.h
@@ -893,17 +893,21 @@ void showMQTTIcon(int32_t posX, int32_t posY, bool forceRedraw) {
 void showEspNowIcon(int32_t posX, int32_t posY, bool forceRedraw) {
     if (!displayShowStatusIcons) return;
 #ifdef SUPPORT_ESPNOW
+    bool espNowStatusActive = activeESPNOW;
+#ifdef SUPPORT_LOW_POWER
+    if ((esp_reset_reason() == ESP_RST_DEEPSLEEP) && (esp_sleep_get_wakeup_cause() == ESP_SLEEP_WAKEUP_TIMER) && !interactiveMode) {
+        espNowStatusActive = deepSleepData.sendESPNowOnWake;
+    }
+#endif
+    if (!espNowStatusActive) return;
+
     if (troubledESPNOW) {
         tft.drawRoundRect(posX - 2, posY - 2, 16 + 4, 16 + 4, 2, TFT_RED);
         tft.drawBitmap(posX, posY, iconEspNow, 16, 16, TFT_BLACK, iconDefaultColor);
         return;
     }
     tft.drawRoundRect(posX - 2, posY - 2, 16 + 4, 16 + 4, 2, TFT_DARKGREY);
-    if (!activeESPNOW) {
-        tft.drawBitmap(posX, posY, iconEspNow, 16, 16, TFT_BLACK, TFT_DARKGREY);
-    } else {
-        tft.drawBitmap(posX, posY, iconEspNow, 16, 16, TFT_BLACK, iconDefaultColor);
-    }
+    tft.drawBitmap(posX, posY, iconEspNow, 16, 16, TFT_BLACK, iconDefaultColor);
 #endif
 }
 

--- a/docs/BTHome.md
+++ b/docs/BTHome.md
@@ -76,7 +76,7 @@ Service data is advertised under UUID **`0xFCD2`**. The first byte is the BTHome
 ### Plain payload
 
 ```
-[0x44] [0x00 packetId] [obj-id data]... 
+[0x44] [0x00 packetId] [obj-id data]...
 ```
 
 `0x00` is the BTHome packet-id object; its value is `bthomePacketId`, incremented
@@ -139,7 +139,9 @@ fit the byte budget. **Group** drives the UI grouping:
   Home Assistant.
 
 Default selection (`BTHOME_DEFAULT_SENSOR_MASK`):
-`battery | temperature | humidity | pressure | co2 | pm25 | pm10`.
+`battery | temperature | humidity | co2`.
+
+Pressure, PM values, battery voltage, and nonnative PM1.0 / PM4.0 are opt-in.
 
 ---
 
@@ -523,7 +525,7 @@ All BTHome work, traced chronologically (non-merge commits,
 | 06-23 | `1835906` | Emulate low-power BTHome availability and reason field |
 
 > Interspersed `Merge branch 'modernization/v2'/'development'` merges are omitted.
-> The current branch name is `feat-bthome-ble`.
+> The current branch name is `bthome-clean`.
 
 ---
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -149,6 +149,9 @@ build_flags =
 ;*** Remove framework default C++11 flag so -std=gnu++17 above takes effect in all envs
 [env]
 build_unflags = -std=gnu++11 -std=c++11 -std=gnu++14 -std=c++14
+lib_ignore =
+    ESPAsyncTCP
+    RPAsyncTCP
 
 ;****************************************************************************************
 ;*** Common data for all builds. You can override this data for each environment below


### PR DESCRIPTION
Adds **BTHome v2** BLE advertising alongside the existing Sensirion Gadget BLE
service, so Home Assistant and other BTHome receivers can consume readings locally
over BLE, no Wi-Fi/MQTT required.

This is the clean replacement for the noisy `feat-bthome-ble` history, opened from
`Tazmania0:bthome-clean` against `melkati:feature/bthome`.

### What's included

- BTHome v2 payloads for battery %, temperature, humidity, pressure, battery voltage,
  CO2, PM2.5, and PM10.
- Optional AES-CCM encryption with bind-key handling and monotonic counter persistence.
- Availability/validity/budget gating so only selected, fresh, in-range, fitting
  measurements are advertised.
- User-selectable BTHome sensors in the Web UI and serial menu.
- Low-power/deep-sleep wake advertising within `BLE_WAKE_ADVERTISEMENT_MS`.
- Mixed-mode advertising: scan response when Sensirion BLE is active, primary advert otherwise.
- Web UI feature visibility fixes, including `setFormGroupVisibility()`,
  `applyFeatureVisibility()`, and `openFirstAvailableTab()`.
- `webEmu` support and docs in `docs/BTHome.md`.

### Code structure

BTHome-specific logic was extracted into `CO2_Gadget_BTHome.h`: measurement table,
encoding, fit/budget logic, encryption, payload build, and advertisement update.

Shared BLE orchestration remains in `CO2_Gadget_BLE.h`.

### Display icon behavior

This PR also adjusts TFT and E-Ink status icons:

- Inactive services are hidden instead of shown as stale/grey icons.
- Status icon areas are cleared before redraw.
- Timer-wake display uses the relevant `deepSleepData` wake flags.
- BTHome has its own icon slot, independent from Sensirion BLE.

If this icon visibility behavior is not desired here, it can be reverted separately
without affecting the core BTHome implementation. OLED is unchanged.

### Notes

PM1.0 / PM4.0 are kept as opt-in, non-native measurements using private object IDs
`0xEE` / `0xEF`. They are emitted last and are not enabled by default.

`SUPPORT_BTHOME_BLE` requires `SUPPORT_BLE`; the branch includes a compile-time guard.

### Verification

```text
git diff --check upstream/feature/bthome..bthome-clean
pio run -e esp32dev
pio run -e TDISPLAY_S3
pio run -e ttgo-t5-EINKBOARDDEPG0213BN
pio run -e esp32dev_OLED