### PR TITLE
fix(calibration): fix web calibration UX and pendingCalibration race (closes #286)

### DIFF
--- a/CO2_Gadget.ino
+++ b/CO2_Gadget.ino
@@ -584,16 +584,20 @@ void advanceCalibrationSequence() {
 void processPendingCommands() {
     if (isDownloadingBLE) return;
     if (pendingCalibration == true) {
-        pendingCalibration = false;
         // Don't calibrate immediately — start the datasheet warm-up sequence, which
         // collects/discards readings (across wakes in low power) before recalibrating.
         if ((calibrationValue >= 400) && (calibrationValue <= 2000)) {
             if (deepSleepData.calPhase == CAL_IDLE) {
+                pendingCalibration = false;  // Only clear when calibration actually starts
                 beginCalibrationSequence(calibrationValue);
             } else {
-                Serial.println("-->[MAIN] Calibration already in progress (warming up to " + String(deepSleepData.calTargetPpm) + " ppm); ignoring new request for " + String(calibrationValue) + " PPM");
+                // Keep pendingCalibration=true so the request retries on next loop;
+                // the warm-up may complete before the next call to processPendingCommands().
+                // See: https://github.com/melkati/CO2-Gadget/issues/286
+                Serial.println("-->[MAIN] Calibration already in progress (warming up to " + String(deepSleepData.calTargetPpm) + " ppm); deferring new request for " + String(calibrationValue) + " PPM");
             }
         } else {
+            pendingCalibration = false;
             Serial.println("-->[MAIN] Avoiding calibrating CO2 sensor with invalid value at " + String(calibrationValue) + " PPM");
         }
     }

--- a/CO2_Gadget.ino
+++ b/CO2_Gadget.ino
@@ -594,7 +594,11 @@ void processPendingCommands() {
                 // Keep pendingCalibration=true so the request retries on next loop;
                 // the warm-up may complete before the next call to processPendingCommands().
                 // See: https://github.com/melkati/CO2-Gadget/issues/286
-                Serial.println("-->[MAIN] Calibration already in progress (warming up to " + String(deepSleepData.calTargetPpm) + " ppm); deferring new request for " + String(calibrationValue) + " PPM");
+                static uint16_t lastDeferredPpm = 0;
+                if (calibrationValue != lastDeferredPpm) {
+                    lastDeferredPpm = calibrationValue;
+                    Serial.println("-->[MAIN] Calibration already in progress (warming up to " + String(deepSleepData.calTargetPpm) + " ppm); deferring new request for " + String(calibrationValue) + " PPM");
+                }
             }
         } else {
             pendingCalibration = false;

--- a/CO2_Gadget_WIFI.h
+++ b/CO2_Gadget_WIFI.h
@@ -1584,6 +1584,8 @@ void initWebServer() {
                     } else {
                         request->send(400, "text/plain", "Error. CO2 calibration value must be between 400 and 2000");
                     }
+                } else {
+                    request->send(400, "text/plain", "Error. CalibrateCO2 must be a number");
                 }
             };
             // <CO2-GADGET_IP>/settings?ToggleDisplayReverse

--- a/webserver/calibration.js
+++ b/webserver/calibration.js
@@ -1,9 +1,15 @@
 // Calibration page logic for CO2 Gadget
 
 (function () {
+    var calPollInFlight = false;
+
     // Poll /getCalibrationStatus to show real warm-up progress
     function pollCalibrationStatus() {
-        fetch('/getCalibrationStatus')
+        if (calPollInFlight) return;  // guard against overlapping polls
+        calPollInFlight = true;
+        var controller = new AbortController();
+        var timeoutId = setTimeout(function () { controller.abort(); }, 5000);
+        fetch('/getCalibrationStatus', { signal: controller.signal })
             .then(function (r) { return r.json(); })
             .then(function (s) {
                 var noteEl = document.getElementById('pendingCalibrationNote');
@@ -21,7 +27,8 @@
                     noteEl.style.display = 'none';
                 }
             })
-            .catch(function () { /* endpoint may not respond during deep sleep */ });
+            .catch(function () { /* endpoint may not respond during deep sleep */ })
+            .finally(function () { clearTimeout(timeoutId); calPollInFlight = false; });
     }
 
     // Live readings — use dedicated sensor endpoints (same as index page)

--- a/webserver/calibration.js
+++ b/webserver/calibration.js
@@ -1,6 +1,29 @@
 // Calibration page logic for CO2 Gadget
 
 (function () {
+    // Poll /getCalibrationStatus to show real warm-up progress
+    function pollCalibrationStatus() {
+        fetch('/getCalibrationStatus')
+            .then(function (r) { return r.json(); })
+            .then(function (s) {
+                var noteEl = document.getElementById('pendingCalibrationNote');
+                if (s.calibrationInProgress) {
+                    var warmupText = 'Warm-up: ' + s.warmupReadings + '/' + s.warmupReadingsRequired +
+                        ' readings, target ' + s.calibrationTargetPpm + ' ppm';
+                    noteEl.textContent = '⏳ ' + warmupText + ' — calibration in progress...';
+                    noteEl.className = 'status-pending';
+                    noteEl.style.display = '';
+                } else if (s.pendingCalibration) {
+                    noteEl.textContent = '⚠ A calibration is pending — the sensor will calibrate on its next measurement cycle.';
+                    noteEl.className = 'status-pending';
+                    noteEl.style.display = '';
+                } else {
+                    noteEl.style.display = 'none';
+                }
+            })
+            .catch(function () { /* endpoint may not respond during deep sleep */ });
+    }
+
     // Live readings — use dedicated sensor endpoints (same as index page)
     function updateReadings() {
         Promise.all([
@@ -16,6 +39,8 @@
 
     updateReadings();
     setInterval(updateReadings, 5000);
+    setInterval(pollCalibrationStatus, 8000);  // poll warm-up status every 8s
+    pollCalibrationStatus();                   // immediate first poll
 
     // Calibrate button
     document.getElementById('btnCalibrate').addEventListener('click', function () {
@@ -29,21 +54,21 @@
         statusEl.textContent = 'Sending calibration command\u2026';
         statusEl.className = '';
         fetch('/settings?CalibrateCO2=' + val)
-            .then(r => {
+            .then(function (r) {
                 if (r.ok) {
-                    return r.text().then(t => {
+                    return r.text().then(function (t) {
                         statusEl.textContent = '\u2713 ' + t;
                         statusEl.className = 'status-ok';
-                        document.getElementById('pendingCalibrationNote').style.display = '';
+                        pollCalibrationStatus();  // immediately show warm-up progress
                     });
                 } else {
-                    return r.text().then(t => {
+                    return r.text().then(function (t) {
                         statusEl.textContent = '\u2717 ' + t;
                         statusEl.className = 'status-err';
                     });
                 }
             })
-            .catch(err => {
+            .catch(function (err) {
                 statusEl.textContent = '\u2717 Network error: ' + err;
                 statusEl.className = 'status-err';
             });

--- a/webserver/preferences.js
+++ b/webserver/preferences.js
@@ -515,21 +515,17 @@ function handlePasswordFields() {
 }
 
 function calibrateSensor(calibrationValue) {
-    // Implement the calibration logic here
-    if (calibrationValue > 400 && calibrationValue < 2000) {
-        console.log("Calibration process started...");
-        console.log("Calibration value:", calibrationValue);
+    if (calibrationValue >= 400 && calibrationValue <= 2000) {
         fetch(`/settings?CalibrateCO2=${calibrationValue}`)
-            .then(response => {
-                if (!response.ok) throw new Error('Error calibrating CO2 sensor');
-                console.log('CO2 sensor calibrated successfully');
+            .then(function (response) {
+                if (!response.ok) throw new Error('Server returned ' + response.status);
+                showPopup('Calibration command sent to ' + calibrationValue + ' ppm. Warm-up in progress.');
             })
-            .catch(error => console.error('Error calibrating CO2 sensor:', error));
+            .catch(function (error) {
+                showPopup('Error: ' + error.message);
+            });
     } else {
-        console.error(
-            "Invalid calibration value, please enter a value between 400 and 2000 ppm"
-        );
-        console.log("Calibration value:", calibrationValue);
+        showPopup('Invalid calibration value: ' + calibrationValue + ' ppm. Must be 400–2000.');
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #286 - web calibration UX and `pendingCalibration` race condition.

### Changes

#### C++ fixes
- **`CO2_Gadget.ino`**: Move `pendingCalibration = false` inside the success branch of `processPendingCommands()`. Previously it was cleared unconditionally before checking `calPhase`, causing calibration commands to be silently lost if they arrived while a warm-up was in progress. Now the flag stays `true` and retries on the next `loop()` iteration.
- **`CO2_Gadget_WIFI.h`**: Add `else` clause in `/settings` handler to send an HTTP 400 response when `CalibrateCO2` parameter is non-numerical (previously no response was sent, causing browser `fetch()` to hang until timeout).

#### JavaScript fixes
- **`calibration.js`**: Poll `/getCalibrationStatus` every 8 seconds to show real warm-up progress (readings X/Y with target ppm) instead of a static "calibration pending" note.
- **`preferences.js`**: Fix range validation from `>` to `>=` (400 and 2000 were incorrectly rejected). Replace `console.log`-only feedback with visible `showPopup()` messages.

### Empirical verification (HIGH_PERFORMANCE mode)

Tested with `CalibrateCO2=600`: sensor reading shifted from 517 ? 590-602 after 182s warm-up. Pipeline confirmed working.

### Files changed
| File | Change |
|------|--------|
| `CO2_Gadget.ino` | Fix `pendingCalibration` race |
| `CO2_Gadget_WIFI.h` | HTTP response for non-numerical input |
| `webserver/calibration.js` | `/getCalibrationStatus` polling |
| `webserver/preferences.js` | Validation fix + showPopup feedback |