### PR TITLE
fix: add WIFI_PRIVACY guard to savePreferences debug log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Unreleased] — v0.16.016-beta (branch: development)
+
+### Fixed
+- **savePreferences debug log**: added `WIFI_PRIVACY` guard to `/savePreferences` debug output for consistency with `printActualSettings()` and `onWifiSettingsChanged()` (`CO2_Gadget_WIFI.h:1860`)
+
+---
+
 ## [Unreleased] — v0.16.015-beta (branch: development)
 
 > **Note:** Versioning reset as of 10 May 2026. The previous v0.14.x line is superseded by v0.15.x on this branch.

--- a/CO2_Gadget_WIFI.h
+++ b/CO2_Gadget_WIFI.h
@@ -1856,7 +1856,7 @@ void initWebServer() {
             String response;
             serializeJson(json, response);
             request->send(200, "application/json", response);
-#ifdef DEBUG_CAPTIVE_PORTAL
+#if defined(DEBUG_CAPTIVE_PORTAL) && !defined(WIFI_PRIVACY)
             Serial.print("-->[WEBS] Received /savePreferences command with content: ");
             Serial.println(response);
 #endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -11,7 +11,7 @@ extra_configs = platformio_extra_configs.ini
 [version]
 build_flags =
     -D CO2_GADGET_VERSION="\"0.16."\"
-    -D CO2_GADGET_REV="\"015-beta\""
+    -D CO2_GADGET_REV="\"016-beta\""
 
 ;****************************************************************************************
 ;*** You can disable features by commenting the line with a semicolon at the beginning


### PR DESCRIPTION
## What
One-line fix: change `#ifdef DEBUG_CAPTIVE_PORTAL` to `#if defined(DEBUG_CAPTIVE_PORTAL) && !defined(WIFI_PRIVACY)` on the savePreferences endpoint debug log.

## Why
The `/savePreferences` debug log in `CO2_Gadget_WIFI.h:1860` is gated only by `DEBUG_CAPTIVE_PORTAL`, while other similar debug logs (`printActualSettings()`, `onWifiSettingsChanged()`) also respect the `WIFI_PRIVACY` flag. This aligns the guard for consistency.

## Files changed
- `CO2_Gadget_WIFI.h` - line 1860: preprocessor guard fix
- `platformio.ini` - version bump: `015-beta` -> `016-beta`
- `CHANGELOG.md` - new entry for v0.16.016-beta

Closes #290