### PR TITLE
fix: remove shadowing of peerESPNowAddress in web save handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - **savePreferences debug log**: added `WIFI_PRIVACY` guard to `/savePreferences` debug output for consistency with `printActualSettings()` and `onWifiSettingsChanged()` (`CO2_Gadget_WIFI.h:1860`)
+- **ESP-NOW peer MAC**: fixed web UI save of peer MAC address — local variable was shadowing the global, causing changes via preferences page to be silently discarded (`CO2_Gadget_Preferences.h:1108`)
 
 ---
 

--- a/CO2_Gadget_Preferences.h
+++ b/CO2_Gadget_Preferences.h
@@ -1105,8 +1105,6 @@ bool handleSavePreferencesFromJSON(String jsonPreferences) {
         // Get the MAC address for peerESPNowAddress as a string from JSON
         if (JsonDocument.containsKey("peerESPNowAddress")) {
             String peerESPNowAddressStr = JsonDocument["peerESPNowAddress"].as<String>();
-            // Convert the string to an array of uint8_t
-            uint8_t peerESPNowAddress[6];
             const char* peerESPNowAddressChar = peerESPNowAddressStr.c_str();
             for (int i = 0; i < 6; i++) {
                 peerESPNowAddress[i] = strtoul(peerESPNowAddressChar + i * 3, NULL, 16);


### PR DESCRIPTION
## What
Remove the local `uint8_t peerESPNowAddress[6]` declaration that was shadowing the global array.

## Why
The local variable was destroyed after the block, so any peer MAC changes made via the web preferences page were silently discarded. The global `peerESPNowAddress[]` (used by ESP-NOW send path and `putPreferences()`) was never updated.

## How
`CO2_Gadget_Preferences.h:1108` - removed `uint8_t peerESPNowAddress[6];` so the existing write accesses go directly to the global.

## Verification
- `pio run -e esp32dev` ? SUCCESS (55s)
- Compiled 74 libraries, 26.1% RAM, 88.7% Flash

Closes #292