### PR TITLE
fix: add format validation to ESP-NOW MAC parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - **savePreferences debug log**: added `WIFI_PRIVACY` guard to `/savePreferences` debug output for consistency with `printActualSettings()` and `onWifiSettingsChanged()` (`CO2_Gadget_WIFI.h:1860`)
 - **ESP-NOW peer MAC**: fixed web UI save of peer MAC address — local variable was shadowing the global, causing changes via preferences page to be silently discarded (`CO2_Gadget_Preferences.h:1108`)
+- **ESP-NOW MAC validation**: added format validation to prevent out-of-bounds read in `strtoul()` parsing of peer MAC address (`CO2_Gadget_Preferences.h:1111`)
 
 ---
 

--- a/CO2_Gadget_Preferences.h
+++ b/CO2_Gadget_Preferences.h
@@ -1105,9 +1105,21 @@ bool handleSavePreferencesFromJSON(String jsonPreferences) {
         // Get the MAC address for peerESPNowAddress as a string from JSON
         if (JsonDocument.containsKey("peerESPNowAddress")) {
             String peerESPNowAddressStr = JsonDocument["peerESPNowAddress"].as<String>();
-            const char* peerESPNowAddressChar = peerESPNowAddressStr.c_str();
-            for (int i = 0; i < 6; i++) {
-                peerESPNowAddress[i] = strtoul(peerESPNowAddressChar + i * 3, NULL, 16);
+            peerESPNowAddressStr.trim();
+            // Expected format: "XX:XX:XX:XX:XX:XX" or "XX-XX-XX-XX-XX-XX" (17 chars).
+            // Validate format before parsing to avoid out-of-bounds reads (UB) on short/invalid input.
+            if (peerESPNowAddressStr.length() >= 17 &&
+                (peerESPNowAddressStr[2] == ':' || peerESPNowAddressStr[2] == '-') &&
+                (peerESPNowAddressStr[5] == ':' || peerESPNowAddressStr[5] == '-') &&
+                (peerESPNowAddressStr[8] == ':' || peerESPNowAddressStr[8] == '-') &&
+                (peerESPNowAddressStr[11] == ':' || peerESPNowAddressStr[11] == '-') &&
+                (peerESPNowAddressStr[14] == ':' || peerESPNowAddressStr[14] == '-')) {
+                const char* peerESPNowAddressChar = peerESPNowAddressStr.c_str();
+                for (int i = 0; i < 6; i++) {
+                    peerESPNowAddress[i] = strtoul(peerESPNowAddressChar + i * 3, NULL, 16);
+                }
+            } else {
+                Serial.println("-->[PREF][WARNING] Invalid ESP-NOW peer MAC format: \"" + peerESPNowAddressStr + "\". Expected XX:XX:XX:XX:XX:XX. Skipping.");
             }
         }
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -11,7 +11,7 @@ extra_configs = platformio_extra_configs.ini
 [version]
 build_flags =
     -D CO2_GADGET_VERSION="\"0.16."\"
-    -D CO2_GADGET_REV="\"016-beta\""
+    -D CO2_GADGET_REV="\"018-beta\""
 
 ;****************************************************************************************
 ;*** You can disable features by commenting the line with a semicolon at the beginning


### PR DESCRIPTION
## What
Add format validation before the `strtoul()` MAC parse loop to prevent out-of-bounds reads on invalid input.

## Why
Copilot review on PR #293 (suppressed comment) identified that `peerESPNowAddressChar + i * 3` assumes a fixed 17-char `XX:XX:XX:XX:XX:XX` format. If the user enters a shorter/invalid string, the pointer arithmetic reads past the null terminator - undefined behavior on ESP32.

## How
`CO2_Gadget_Preferences.h:1106-1123` - validate length (>= 17) and separator positions (accept `:` or `-`) before parsing. Invalid input is logged with a `[WARNING]` and skipped, preserving the previous MAC value.

## Files changed
- `CO2_Gadget_Preferences.h` - MAC format validation
- `platformio.ini` - version bump: 017-beta ? 018-beta
- `CHANGELOG.md` - new entry

## Verification
- Builds with `pio run -e esp32dev` (SUCCESS)
- Builds with `-DSUPPORT_ESPNOW` (SUCCESS)
- Valid MAC `E8:68:E7:0F:08:90` ? parses correctly
- Invalid MAC `E8:68:E7:0F` ? logs warning, skips (no UB)

Reopens-and-closes #292